### PR TITLE
Clone with HTTPS instead of SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Soon we hope to add notebooks from the researchers, technologists, geographers, 
 
 ### Clone the repo:
 ```bash
-git clone git@github.com:planetlabs/notebooks.git
+git clone https://github.com/planetlabs/notebooks.git
 cd notebooks
 ```
 


### PR DESCRIPTION
Cloning with SSH may lead to unnecessary permission errors.

Fixes #26