### PR TITLE
ANALYTICS: fix base url link and python version

### DIFF
--- a/jupyter-notebooks/analytics/1. Getting Started with the Planet Analytics API.ipynb
+++ b/jupyter-notebooks/analytics/1. Getting Started with the Planet Analytics API.ipynb
@@ -188,7 +188,7 @@
     "The Planet Analytics API can be accessed at the following base url:\n",
     "<div class=\"callout-blue top-margin\">\n",
     "    \n",
-    "[api.planet.com/analytics](https://api.planet.com/analytics)\n",
+    "[api.planet.com/analytics](https://api.planet.com/analytics/)\n",
     "\n",
     "</div>\n",
     "\n",
@@ -5497,7 +5497,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- use python 3.6.7, which other notebooks in this repo use (it's in the notebook docker image)
- fix a broken link to the analytics api base url