### PR TITLE
BUG Small fixes to analytics quickstart NBs

### DIFF
--- a/jupyter-notebooks/analytics/quickstart/01_checking_available_feeds_and_subscriptions.ipynb
+++ b/jupyter-notebooks/analytics/quickstart/01_checking_available_feeds_and_subscriptions.ipynb
@@ -159,7 +159,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import pandas as pd\n",
@@ -169,7 +171,7 @@
     "df = pd.DataFrame(feeds)\n",
     "# instead of including the entire source and target dicts, make columns for the types\n",
     "df['targetType'] = df['target'].map(lambda t: t['type'])\n",
-    "df['sourceType'] = df['source'].map(lambda t: t['type'])\n",
+    "df['sourceType'] = df['source'].map(lambda t: \";\".join(e['type'] for e in t))\n",
     "df[['id', 'title', 'description', 'sourceType', 'targetType', 'created', 'updated']]\n"
    ]
   },
@@ -249,7 +251,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "df = pd.DataFrame(subs)\n",
@@ -342,9 +346,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.9.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/jupyter-notebooks/analytics/quickstart/02_fetching_feed_results.ipynb
+++ b/jupyter-notebooks/analytics/quickstart/02_fetching_feed_results.ipynb
@@ -61,7 +61,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import pandas as pd\n",
@@ -101,7 +103,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import json\n",
@@ -200,7 +204,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "next_results = requests.get(next_link, auth=BASIC_AUTH).json()\n",
@@ -275,6 +281,9 @@
     "        print('Fetched {} features fetched ({}, {})'.format(\n",
     "            len(next_features), earliest_feature_creation, latest_feature_creation))\n",
     "        feature_collection['features'].extend(next_features)\n",
+    "        if earliest_feature_creation < min_date:\n",
+    "            # The next set of features would be from before our minimum date.\n",
+    "            break\n",
     "        next_link = get_next_link(results)\n",
     "    else:\n",
     "        next_link = None\n",
@@ -355,9 +364,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.9.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/jupyter-notebooks/analytics/quickstart/03_visualizing_raster_results.ipynb
+++ b/jupyter-notebooks/analytics/quickstart/03_visualizing_raster_results.ipynb
@@ -61,7 +61,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import pandas as pd\n",
@@ -274,7 +276,7 @@
     "        with open(dest_path, 'wb') as f:\n",
     "            resp.raw.decode_content = True\n",
     "            shutil.copyfileobj(resp.raw, f)\n",
-    "        print('Saved file:', path)\n",
+    "        print('Saved file:', dest_path)\n",
     "    else:\n",
     "        print('Something is wrong:', resp.content)\n",
     "\n",
@@ -627,9 +629,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.9.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/planet-notebook-docker/README.md
+++ b/planet-notebook-docker/README.md
@@ -1,6 +1,6 @@
 # Planet Notebook
 
-This image provides the dependencies for running jupyter notebooks in the [planetlabs/notebooks](https://github.com/planetlabs/notebooks) GitHub repository. A prebuilt version of this image can be downloaded from the [planetlabs/notebook](https://hub.docker.com/r/planetlabs/notebooks) dockerhub repo (recommended). Alternatively, this image can be built locally from the Dockerfile. The specifics of building and running this image are given in the planetlabs/notebooks GitHub [README.md](https://github.com/planetlabs/notebooks/blob/master/README.md) file.
+This image provides the dependencies for running jupyter notebooks in the [planetlabs/notebooks](https://github.com/planetlabs/notebooks) GitHub repository. A prebuilt version of this image can be downloaded from the [planetlabs/notebooks](https://hub.docker.com/r/planetlabs/notebooks) dockerhub repo (recommended). Alternatively, this image can be built locally from the Dockerfile. The specifics of building and running this image are given in the planetlabs/notebooks GitHub [README.md](https://github.com/planetlabs/notebooks/blob/master/README.md) file.
 
 This image is based on the [jupyter/minimal-notebook](https://hub.docker.com/r/jupyter/minimal-notebook/) image and additional tips on running the jupyter notebook can be found in the documentation for that image.
 


### PR DESCRIPTION
In notebook 01, I found that the "source" column contained a list; check the "type" field for each element of the list separately.

In notebook 02, the code implied a desired limit to retrieved features based on date, but the cutoff wasn't present. This is the minimal change to add a limit -- it will include features from before the cutoff if they're on the same page as features after the cutoff.

In notebook 03, fix a typo which put the wrong variable name in the `donwload_file` helper function.