### PR TITLE
WEBTILES: remove unnecessary interval field from search body

### DIFF
--- a/jupyter-notebooks/webtiles/visualize_imagery_over_time.ipynb
+++ b/jupyter-notebooks/webtiles/visualize_imagery_over_time.ipynb
@@ -135,7 +135,6 @@
     "    # Setup the request\n",
     "    filter_request = {\n",
     "        \"item_types\" : [item_type],\n",
-    "        \"interval\" : \"year\",\n",
     "        \"filter\" : and_filter\n",
     "    }\n",
     "    # get ids from search results\n",


### PR DESCRIPTION
Tried this notebook for the first time in a while and discovered that the data api search request was failing because of an extra unnecessary `"interval"` field in the search body.