### PR TITLE
Fixed many broken links across notebooks

### DIFF
--- a/jupyter-notebooks/analysis-ready-data/ard_1_intro_and_best_practices.ipynb
+++ b/jupyter-notebooks/analysis-ready-data/ard_1_intro_and_best_practices.ipynb
@@ -44,7 +44,7 @@
     "\n",
     "### Orders API\n",
     "\n",
-    "The core decision around using the orders api is which [product bundle](https://developers.planet.com/docs/orders/product-bundles-reference/) to use. This is the starting point for all processing and there are a lot of options. Once the product is determined, the processing steps (aka tools and toolchains) are defined. Finally, the logistics of the delivery of the imagery are ironed out.\n",
+    "The core decision around using the orders api is which [product bundle](https://developers.planet.com/apis/orders/product-bundles-reference/) to use. This is the starting point for all processing and there are a lot of options. Once the product is determined, the processing steps (aka tools and toolchains) are defined. Finally, the logistics of the delivery of the imagery are ironed out.\n",
     "\n",
     "#### Product Bundle\n",
     "\n",
@@ -52,11 +52,11 @@
     "\n",
     "#### Tools and Toolchains\n",
     "\n",
-    "The [Tools and Toolchains](https://developers.planet.com/docs/orders/tools-toolchains/) functionality in the Orders API are the key to seamlessly creating ARD. Through the API, one can define the pre-processing steps for the data before it is delivered. Given proper definition of the tools and toolchains, data that is delivered is analysis-ready.\n",
+    "The [Tools and Toolchains](https://developers.planet.com/apis/orders/tools/) functionality in the Orders API are the key to seamlessly creating ARD. Through the API, one can define the pre-processing steps for the data before it is delivered. Given proper definition of the tools and toolchains, data that is delivered is analysis-ready.\n",
     "\n",
     "#### Delivery\n",
     "\n",
-    "There are a few options for delivery that cater to different use cases. Imagery can be downloaded directly or delivered to [cloud storage](https://developers.planet.com/docs/orders/ordering-delivery/#delivery-to-cloud-storage). When imagery is downloaded, the user can poll for when the order is ready or notifications ([e-mail](https://developers.planet.com/docs/orders/ordering-delivery/#email-notification) or [webhooks](https://developers.planet.com/docs/orders/ordering-delivery/#using-webhooks)) can be used. Additionally, the imagery can be delivered as a [zip archive](https://developers.planet.com/docs/orders/ordering-delivery/#zipping-results).\n",
+    "There are a few options for delivery that cater to different use cases. Imagery can be downloaded directly or delivered to [cloud storage](https://developers.planet.com/docs/orders/ordering-delivery/#delivery-to-cloud-storage). When imagery is downloaded, the user can poll for when the order is ready or notifications ([e-mail](https://developers.planet.com/apis/orders/notifications/) or [webhooks](https://developers.planet.com/apis/orders/notifications/#:~:text=notifications%22%3A%7B%0A%20%20%20%20%20%20%22email%22%3A%20true%0A%20%20%20%7D%0A%7D-,Webhook%20Notifications,-To%20enable%20webhook)) can be used. Additionally, the imagery can be delivered as a [zip archive](https://developers.planet.com/apis/orders/delivery/#:~:text=path_prefix%22%3A%20%22folder1/prefix/%22%0A%20%20%20%20%20%20%7D%0A%20%20%20%7D%0A%7D-,Zipping%20results,-With%20the%20zip).\n",
     "\n",
     "## Best Practices\n",
     "\n",
@@ -782,7 +782,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/jupyter-notebooks/analytics-snippets/README.md
+++ b/jupyter-notebooks/analytics-snippets/README.md
@@ -4,5 +4,5 @@ This directory holds notebooks that demonstrate quick code snippets useful
 for working with the analytics output.
 
 Snippets include:
-- converting the roads raster to a vector dataset ([notebook](roads_as_vector.ipynb))
-- converting the building footprint raster to a vector dataset ([notebook](building_footprints_as_vector.ipynb))
+- converting the roads raster to a vector dataset ([notebook](https://github.com/planetlabs/notebooks/blob/master/jupyter-notebooks/analytics-snippets/raster_to_vector_roads.ipynb))
+- converting the building footprint raster to a vector dataset ([notebook](https://github.com/planetlabs/notebooks/blob/master/jupyter-notebooks/analytics-snippets/raster_to_vector_buildingfootprints.ipynb))

--- a/jupyter-notebooks/analytics/user-guide/01_getting_started_with_the_planet_analytics_api.ipynb
+++ b/jupyter-notebooks/analytics/user-guide/01_getting_started_with_the_planet_analytics_api.ipynb
@@ -580,7 +580,7 @@
     "\n",
     "We also see a `target` property containing `type`, which will let us know what kind of **Results** the Feed generates (collections of features vs raster mosaics).\n",
     "\n",
-    "Under the `source` property, we see the configuration for the source imagery that the Feed operates on. The `query` property under `source` `config` should be familiar if you've worked with the [Planet Data API](https://developers.planet.com/docs/api/), and we can see which Planet `item type` the Feed is configured to use (ex. `PSScene`). \n",
+    "Under the `source` property, we see the configuration for the source imagery that the Feed operates on. The `query` property under `source` `config` should be familiar if you've worked with the [Planet Data API](https://developers.planet.com/docs/apis/data/), and we can see which Planet `item type` the Feed is configured to use (ex. `PSScene`). \n",
     "\n",
     "Finally the `links` property is also available as we've seen before.\n",
     "\n",
@@ -1139,7 +1139,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/jupyter-notebooks/crossovers/ps_l8_crossovers.ipynb
+++ b/jupyter-notebooks/crossovers/ps_l8_crossovers.ipynb
@@ -372,7 +372,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "It looks like the collection period is 16 days, which lines up with the [Landsat 8 mission description](https://landsat.usgs.gov/landsat-8).\n",
+    "It looks like the collection period is 16 days, which lines up with the [Landsat 8 mission description](https://www.usgs.gov/landsat-missions/landsat-8).\n",
     "\n",
     "path/row 43/33 is missing one image which causes an unusually long collect period.\n",
     "\n",
@@ -752,7 +752,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/jupyter-notebooks/data-api-tutorials/README.md
+++ b/jupyter-notebooks/data-api-tutorials/README.md
@@ -1,6 +1,6 @@
 ## Using Python to access Planet's imagery
 
-These guides are designed for users who want to learn how to programmatically access Planet's data archive. With just a few lines of Python, you can interact with Planet's [Data API](https://api.planet.com/data/v1) to quick-search types of imagery, create filters based on target parameters, and activate and downland images and metadata. If you'd like to start with a visual exploration of Planet data over time, visit [Planet Explorer](https://www.planet.com/explorer/), and then circle back to these API-based guides. 
+These guides are designed for users who want to learn how to programmatically access Planet's data archive. With just a few lines of Python, you can interact with Planet's [Data API](https://developers.planet.com/docs/apis/data/) to quick-search types of imagery, create filters based on target parameters, and activate and downland images and metadata. If you'd like to start with a visual exploration of Planet data over time, visit [Planet Explorer](https://www.planet.com/explorer/), and then circle back to these API-based guides. 
 
 ### Choose your own adventure
 The first notebook uses the Python `requests` library and a few lines of helper code to explore the full functionality of the Data API. The second guide uses Planet's Python command-line interface to quickly step through a common workflow of searching, activating, and downloading imagery. 
@@ -10,7 +10,6 @@ The first notebook uses the Python `requests` library and a few lines of helper 
 
 ### Read the docs
 * [Python Client for Planet API](https://planetlabs.github.io/planet-client-python/index.html)
-* [Planet API Reference](https://www.planet.com/docs/reference/)
-* [Common Workflows for the Data API](https://www.planet.com/docs/reference/data-api/common-workflows/)
+* [Planet API Reference](https://developers.planet.com/docs/apis/?gclid=Cj0KCQiAm5ycBhCXARIsAPldzoVPk5WyPLW3ZOiUhpUF6HDkeyYikDsdUG_WDjTK3wdUZMknKE1Bhg4aAtA0EALw_wcB)
 
 *Planeteer [Benjamin Trigona-Harany](https://github.com/bosth) originally wrote these tutorials for Planet's developer partners. [Orestis Herodotou](https://github.com/digitaltopo) modified them for Planet's [Impact Partner](https://www.planet.com/markets/impact/) program.*

--- a/jupyter-notebooks/data-api-tutorials/planet_data_api_introduction.ipynb
+++ b/jupyter-notebooks/data-api-tutorials/planet_data_api_introduction.ipynb
@@ -115,7 +115,7 @@
     "\n",
     "---\n",
     "\n",
-    "* [Planet Data API Reference & Documentation](https://www.planet.com/docs/reference/data-api/)\n",
+    "* [Planet Data API Reference & Documentation](https://developers.planet.com/docs/apis/data/)\n",
     "* [Planet Explorer](https://www.planet.com/explorer)"
    ]
   },
@@ -557,7 +557,7 @@
     "* `AndFilter`\n",
     "* `OrFilter`\n",
     "\n",
-    "More information and examples on filter types can be found at the [API Docs](https://www.planet.com/docs/reference/data-api/search-api/). \n",
+    "More information and examples on filter types can be found at the [API Docs](https://developers.planet.com/docs/apis/). \n",
     "\n",
     "---\n",
     "\n",
@@ -1759,7 +1759,7 @@
     "\n",
     "You made it! You should now be able to use the Planet API to find items and assets by searching, get stats and save searches, and activate and download assets using Python code! \n",
     "\n",
-    "Don't forget to visit the [Planet API Reference Docs](https://www.planet.com/docs/reference/).\n"
+    "Don't forget to visit the [Planet API Reference Docs](https://developers.planet.com/docs/apis/).\n"
    ]
   }
  ],
@@ -1779,7 +1779,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/jupyter-notebooks/forest-monitoring/drc_roads_mosaic.ipynb
+++ b/jupyter-notebooks/forest-monitoring/drc_roads_mosaic.ipynb
@@ -189,7 +189,7 @@
     "\n",
     "To classify the mosaics into forest and non-forest, we use the Random Forests classifier. This is a supervised classification technique, so we need to create a training dataset. The training dataset will be created from one mosaic image and then the trained classifier will classify all mosaic images.\n",
     "\n",
-    "Although we have already performed classification of a 4-band Orthotile into forest and non-forest in [drc_roads_classification](drc_roads_classification.ipnb), the format of the data is different in mosaics, so we need to re-create our training dataset. However, we will use the same label images that were created as a part of that notebook. Additionally, we will pull a lot of code from that notebook.\n",
+    "Although we have already performed classification of a 4-band Orthotile into forest and non-forest in [drc_roads_classification](https://github.com/planetlabs/notebooks/blob/master/jupyter-notebooks/forest-monitoring/drc_roads_classification.ipynb), the format of the data is different in mosaics, so we need to re-create our training dataset. However, we will use the same label images that were created as a part of that notebook. Additionally, we will pull a lot of code from that notebook.\n",
     "\n",
     "### Create Label Masks"
    ]
@@ -1065,7 +1065,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1079,7 +1079,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/jupyter-notebooks/in-class-exercises/band-math-generate-ndvi/generate-ndvi-exercise-key.ipynb
+++ b/jupyter-notebooks/in-class-exercises/band-math-generate-ndvi/generate-ndvi-exercise-key.ipynb
@@ -36,7 +36,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To create this vegetation index, we're going to use PlanetScope's SR _(Surface Reflectance)_ data product. You can learn [more about Surface Reflectance (SR) and Planet data here](https://support.planet.com/hc/en-us/sections/115003720348-Surface-Reflectance), but for the purposes of this exercise, all you need to know is: SR data is satellite data that has been algorithmically corrected to remove atmospheric interference."
+    "To create this vegetation index, we're going to use PlanetScope's SR _(Surface Reflectance)_ data product. You can learn [more about Surface Reflectance (SR) and Planet data here](https://developers.planet.com/docs/data/sr-basemaps/), but for the purposes of this exercise, all you need to know is: SR data is satellite data that has been algorithmically corrected to remove atmospheric interference."
    ]
   },
   {
@@ -63,7 +63,7 @@
     "- [rasterio](https://github.com/mapbox/rasterio)\n",
     "- [numpy](http://www.numpy.org/)\n",
     "- [matplotlib](https://matplotlib.org/)\n",
-    "- [Planet API Key](https://developers.planet.com/docs/quickstart/getting-started/), stored as environment variable `$PL_API_KEY`.\n",
+    "- [Planet API Key](https://developers.planet.com/quickstart/apis/#:~:text=active%20Planet%20accounts.-,Find%20your%20API%20Key,-Once%20you%27re%20signed), stored as environment variable `$PL_API_KEY`.\n",
     "- [Planet 4-Band Imagery](https://developers.planet.com/docs/api/psscene/) with the following specifications: `item-type`: `PSScene`; `asset-type`: `ortho_analytic_4b_sr`"
    ]
   },
@@ -467,7 +467,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -481,7 +481,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/jupyter-notebooks/in-class-exercises/band-math-generate-ndvi/generate-ndvi-exercise.ipynb
+++ b/jupyter-notebooks/in-class-exercises/band-math-generate-ndvi/generate-ndvi-exercise.ipynb
@@ -39,7 +39,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To create this vegetation index, we're going to use PlanetScope's SR _(Surface Reflectance)_ data product. You can learn [more about Surface Reflectance (SR) and Planet data here](https://support.planet.com/hc/en-us/sections/115003720348-Surface-Reflectance), but for the purposes of this exercise, all you need to know is: SR data is satellite data that has been algorithmically corrected to remove atmospheric interference. If you'd like to learn much more about reflectance conversions and atmospheric interference, see [this in-class exercise](../convert-radiance-to-reflectance/convert-radiance-to-reflectance-key.ipynb)."
+    "To create this vegetation index, we're going to use PlanetScope's SR _(Surface Reflectance)_ data product. You can learn [more about Surface Reflectance (SR) and Planet data here](https://developers.planet.com/docs/data/sr-basemaps/), but for the purposes of this exercise, all you need to know is: SR data is satellite data that has been algorithmically corrected to remove atmospheric interference. If you'd like to learn much more about reflectance conversions and atmospheric interference, see [this in-class exercise](../convert-radiance-to-reflectance/convert-radiance-to-reflectance-key.ipynb)."
    ]
   },
   {
@@ -66,7 +66,7 @@
     "- [rasterio](https://github.com/mapbox/rasterio)\n",
     "- [numpy](http://www.numpy.org/)\n",
     "- [matplotlib](https://matplotlib.org/)\n",
-    "- [Planet API Key](https://developers.planet.com/docs/quickstart/getting-started/), stored as environment variable `$PL_API_KEY`.\n",
+    "- [Planet API Key](https://developers.planet.com/quickstart/apis/#:~:text=active%20Planet%20accounts.-,Find%20your%20API%20Key,-Once%20you%27re%20signed), stored as environment variable `$PL_API_KEY`.\n",
     "- [Planet 4-Band Imagery](https://developers.planet.com/docs/api/psscene/) with the following specifications: `item-type`: `PSScene`; `asset-type`: `ortho_analytic_4b_sr`"
    ]
   },
@@ -493,7 +493,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -507,7 +507,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/jupyter-notebooks/in-class-exercises/convert-radiance-to-reflectance/convert-radiance-to-reflectance-key.ipynb
+++ b/jupyter-notebooks/in-class-exercises/convert-radiance-to-reflectance/convert-radiance-to-reflectance-key.ipynb
@@ -70,7 +70,7 @@
    "source": [
     "### Requirements\n",
     "- Python 2.7 or 3+\n",
-    "- [Planet's Python Client](https://www.planet.com/docs/api-quickstart-examples/cli/)\n",
+    "- [Planet's Python Client](https://developers.planet.com/docs/planetschool/get-started-with-planet-cli-searching-for-data/?gclid=Cj0KCQiAm5ycBhCXARIsAPldzoV1kaH5RV3yIx96l0vCd34nXWORqGqgIrs5f0thv-TYy5FtbZP6b9gaAtZCEALw_wcB)\n",
     "- [rasterio](https://github.com/mapbox/rasterio)\n",
     "- [numpy](http://www.numpy.org/)\n",
     "- [matplotlib](https://matplotlib.org/)\n",
@@ -94,8 +94,8 @@
     "To search for your own data, you'll first need to define an Area of Interest (AOI). [http://geojson.io](http://geojson.io) is a free browser-based tool that makes generating a GeoJSON-formatted AOI easy.\n",
     "\n",
     "Once that's done, use one of the following methods to search for & download data:\n",
-    "- using [Planet's Python CLI](https://www.planet.com/docs/api-quickstart-examples/cli/) to interact with Planet's API from the command line\n",
-    "- using Planet's API directly to [search](https://developers.planet.com/docs/quickstart/searching-for-imagery/) and [download](https://developers.planet.com/docs/quickstart/downloading-imagery/)\n",
+    "- using [Planet's Python CLI](https://developers.planet.com/docs/planetschool/get-started-with-planet-cli-searching-for-data/?gclid=Cj0KCQiAm5ycBhCXARIsAPldzoV1kaH5RV3yIx96l0vCd34nXWORqGqgIrs5f0thv-TYy5FtbZP6b9gaAtZCEALw_wcB) to interact with Planet's API from the command line\n",
+    "- using Planet's API directly to [search](https://developers.planet.com/quickstart/apis/#:~:text=Conducting%20an%20image%20search) and [download](https://developers.planet.com/quickstart/apis/#:~:text=Activating%20%26%20downloading%20the%20image)\n",
     "- using the [Planet Explorer](https://www.planet.com/products/explorer/) site to visually search for & download data\n",
     "\n",
     "With all of the above, you'll want to filter for 4-Band PlanetScope data (item type: `PSScene`) and download the associated analytic product (asset type: `ortho_analytic_4b`)."
@@ -136,7 +136,7 @@
    "source": [
     "### Option 2: Searching & Downloading via API\n",
     "\n",
-    "If you prefer to use Planet's API directly via Python, this [search & download quickstart Notebook](../../data-api-tutorials/search_and_download_quickstart.ipynb) may be useful."
+    "If you prefer to use Planet's API directly via Python, this [search & download quickstart Notebook](https://github.com/planetlabs/notebooks/blob/master/jupyter-notebooks/data-api-tutorials/search_and_download_quickstart.ipynb) may be useful."
    ]
   },
   {
@@ -374,13 +374,13 @@
    "source": [
     "Congratulations! You've learned how to apply coefficient metadata to a GeoTIFF in order to atmospherically correct radiance values, converting them to reflectance.\n",
     "\n",
-    "From here, you could use your new reflectance image to generate indices such as an NDVI. To learn more about how to do that, see [band-math-generate-ndvi/generate-ndvi-exercise.ipynb](band-math-generate-ndvi/generate-ndvi-exercise.ipynb)."
+    "From here, you could use your new reflectance image to generate indices such as an NDVI. To learn more about how to do that, see [band-math-generate-ndvi/generate-ndvi-exercise.ipynb](https://github.com/planetlabs/notebooks/blob/master/jupyter-notebooks/in-class-exercises/band-math-generate-ndvi/generate-ndvi-exercise.ipynb)."
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -394,7 +394,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/jupyter-notebooks/in-class-exercises/convert-radiance-to-reflectance/convert-radiance-to-reflectance.ipynb
+++ b/jupyter-notebooks/in-class-exercises/convert-radiance-to-reflectance/convert-radiance-to-reflectance.ipynb
@@ -74,7 +74,7 @@
    "source": [
     "### Requirements\n",
     "- Python 2.7 or 3+\n",
-    "- [Planet's Python Client](https://www.planet.com/docs/api-quickstart-examples/cli/)\n",
+    "- [Planet's Python Client](https://developers.planet.com/docs/planetschool/get-started-with-planet-cli-searching-for-data/?gclid=Cj0KCQiAm5ycBhCXARIsAPldzoV1kaH5RV3yIx96l0vCd34nXWORqGqgIrs5f0thv-TYy5FtbZP6b9gaAtZCEALw_wcB)\n",
     "- [rasterio](https://github.com/mapbox/rasterio)\n",
     "- [numpy](http://www.numpy.org/)\n",
     "- [matplotlib](https://matplotlib.org/)\n",
@@ -98,7 +98,7 @@
     "To search for your own data, you'll first need to define an Area of Interest (AOI). [http://geojson.io](http://geojson.io) is a free browser-based tool that makes generating a GeoJSON-formatted AOI easy.\n",
     "\n",
     "Once that's done, use one of the following methods to search for & download data:\n",
-    "- using [Planet's Python CLI](https://www.planet.com/docs/api-quickstart-examples/cli/) to interact with Planet's API from the command line\n",
+    "- using [Planet's Python CLI](https://developers.planet.com/docs/planetschool/get-started-with-planet-cli-searching-for-data/?gclid=Cj0KCQiAm5ycBhCXARIsAPldzoV1kaH5RV3yIx96l0vCd34nXWORqGqgIrs5f0thv-TYy5FtbZP6b9gaAtZCEALw_wcB) to interact with Planet's API from the command line\n",
     "- using Planet's API directly to [search](https://developers.planet.com/docs/quickstart/searching-for-imagery/) and [download](https://developers.planet.com/docs/quickstart/downloading-imagery/)\n",
     "- using the [Planet Explorer](https://www.planet.com/products/explorer/) site to visually search for & download data\n",
     "\n",
@@ -116,7 +116,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you choose to use Planet's CLI, you might fight these [search](https://developers.planet.com/docs/quickstart/searching-for-imagery/) and [download](https://developers.planet.com/docs/quickstart/downloading-imagery/) quickstart guides to be useful."
+    "If you choose to use Planet's CLI, you might fight these [search](https://developers.planet.com/quickstart/apis/#:~:text=Conducting%20an%20image%20search) and [download](https://developers.planet.com/quickstart/apis/#:~:text=Activating%20%26%20downloading%20the%20image) quickstart guides to be useful."
    ]
   },
   {
@@ -385,13 +385,13 @@
    "source": [
     "Congratulations! You've learned how to apply coefficient metadata to a GeoTIFF in order to atmospherically correct radiance values, converting them to reflectance.\n",
     "\n",
-    "From here, you could use your new reflectance image to generate indices such as an NDVI. To learn more about how to do that, see [band-math-generate-ndvi/generate-ndvi-exercise.ipynb](band-math-generate-ndvi/generate-ndvi-exercise.ipynb)."
+    "From here, you could use your new reflectance image to generate indices such as an NDVI. To learn more about how to do that, see [band-math-generate-ndvi/generate-ndvi-exercise.ipynb](https://github.com/planetlabs/notebooks/blob/master/jupyter-notebooks/in-class-exercises/band-math-generate-ndvi/generate-ndvi-exercise.ipynb)."
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -405,7 +405,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/jupyter-notebooks/landsat-ps-comparison/landsat-ps-comparison.ipynb
+++ b/jupyter-notebooks/landsat-ps-comparison/landsat-ps-comparison.ipynb
@@ -61,7 +61,7 @@
     "\n",
     "These scenes represent a crossover between Landsat8 and PlanetScope on July 25, 2017.\n",
     "\n",
-    "For the Landsat8L1G scene, we download band 5, which is the NIR band ([ref](https://landsat.usgs.gov/what-are-band-designations-landsat-satellites)).\n",
+    "For the Landsat8L1G scene, we download band 5, which is the NIR band ([ref](https://www.usgs.gov/faqs/what-are-band-designations-landsat-satellites)).\n",
     "\n",
     "To download the scenes, we use the planet CLI because it handles activating, waiting for activation, and downloading the file.\n",
     "\n",
@@ -464,7 +464,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Interestingly, it appears the square field which pops out in the difference image is less differentiated from the surrounding fields in the Landsat scene than in the PlanetScope scene. Since both scenes were collected on the same day, this is likely due to a different in the spectral responses of the NIR bands for the two sensors combined with the crop type of that field. The center wavelength of the NIR response for the PlanetScope sensor is 825nm, while it is [865nm for the Landsat sensor](https://landsat.gsfc.nasa.gov/preliminary-spectral-response-of-the-operational-land-imager-in-band-band-average-relative-spectral-response/). This shows that an analysis utilizing both Landsat8 and PlanetScope scenes may be able to better differentiate crop types. There is great potential in combining scenes from multiple sensors for analysis."
+    "Interestingly, it appears the square field which pops out in the difference image is less differentiated from the surrounding fields in the Landsat scene than in the PlanetScope scene. Since both scenes were collected on the same day, this is likely due to a different in the spectral responses of the NIR bands for the two sensors combined with the crop type of that field. The center wavelength of the NIR response for the PlanetScope sensor is 825nm, while it is [865nm for the Landsat sensor](https://landsat.gsfc.nasa.gov/article/preliminary-spectral-response-of-the-operational-land-imager-in-band-band-average-relative-spectral-response/). This shows that an analysis utilizing both Landsat8 and PlanetScope scenes may be able to better differentiate crop types. There is great potential in combining scenes from multiple sensors for analysis."
    ]
   },
   {
@@ -477,7 +477,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -491,7 +491,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/jupyter-notebooks/ndvi-from-sr/ndvi_planetscope_sr.ipynb
+++ b/jupyter-notebooks/ndvi-from-sr/ndvi_planetscope_sr.ipynb
@@ -55,12 +55,12 @@
    "source": [
     "### Requirements\n",
     "- Python 3+\n",
-    "- [Planet's Python Client](https://www.planet.com/docs/api-quickstart-examples/cli/)\n",
+    "- [Planet's Python Client](https://developers.planet.com/docs/planetschool/get-started-with-planet-cli-searching-for-data/?gclid=Cj0KCQiAm5ycBhCXARIsAPldzoUordT6Gv03a-aKQJfZQ2DAyvOcCoTdXUanChjLnNtFHy3PGiousAwaAihpEALw_wcB)\n",
     "- [rasterio](https://github.com/mapbox/rasterio)\n",
     "- [numpy](http://www.numpy.org/)\n",
     "- [matplotlib](https://matplotlib.org/)\n",
     "- [Planet API Key](https://www.planet.com/account/#/), stored as environment variable `$PL_API_KEY`.\n",
-    "- [Planet 4-Band Imagery](https://www.planet.com/docs/imagery-quickstart/) with the following specifications: `item-type`: `PSScene`; `asset-type`: `ortho_analytic_4b_sr`"
+    "- [Planet 4-Band Imagery](https://developers.planet.com/quickstart/apis/#:~:text=Quickstart%3A%20Search%20%26%20Download%20Imagery) with the following specifications: `item-type`: `PSScene`; `asset-type`: `ortho_analytic_4b_sr`"
    ]
   },
   {
@@ -74,9 +74,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First, you're going to download a [4-band PlanetScope Surface Reflectance product](https://www.planet.com/docs/spec-sheets/sat-imagery/#ps-imagery-product) of agricultural land in California's Central Valley, captured in late August 2016 (`item-id`: `20160831_180302_0e26`). You can do this using [Planet's Python client](https://www.planet.com/docs/api-quickstart-examples/cli/) to interact with our Data API, or by browsing [Planet Explorer](https://www.planet.com/products/explorer/), filtering for 4 Band PlanetScope scene (`PSScene`), and downloading an `ortho_analytic_4b_sr` asset.\n",
+    "First, you're going to download a [4-band PlanetScope Surface Reflectance product](https://www.planet.com/docs/spec-sheets/sat-imagery/#ps-imagery-product) of agricultural land in California's Central Valley, captured in late August 2016 (`item-id`: `20160831_180302_0e26`). You can do this using [Planet's Python client](https://developers.planet.com/docs/planetschool/get-started-with-planet-cli-searching-for-data/?gclid=Cj0KCQiAm5ycBhCXARIsAPldzoUordT6Gv03a-aKQJfZQ2DAyvOcCoTdXUanChjLnNtFHy3PGiousAwaAihpEALw_wcB) to interact with our Data API, or by browsing [Planet Explorer](https://www.planet.com/products/explorer/), filtering for 4 Band PlanetScope scene (`PSScene`), and downloading an `ortho_analytic_4b_sr` asset.\n",
     "\n",
-    "Before you download the full image, you can [preview a thumbnail](https://www.planet.com/docs/reference/data-api/previews/) of the image via Planet's Data API. (The thumbnails are 256x256 by default, and can be scaled up to 512x512 by passing in a `width` parameter.) "
+    "Before you download the full image, you can [preview a thumbnail](https://developers.planet.com/docs/apis/data/item-previews/) of the image via Planet's Data API. (The thumbnails are 256x256 by default, and can be scaled up to 512x512 by passing in a `width` parameter.) "
    ]
   },
   {
@@ -107,7 +107,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, you'll use [Planet's Python client](https://planetlabs.github.io/planet-client-python/index.html) to download the image. *Note: when you run this command, you'll get a stream of messages in your Jupyter notebook as the Python client polls the Data API to determine if the image is [activated and ready to download](https://www.planet.com/docs/api-quickstart-examples/step-2-download/#activate).*"
+    "Next, you'll use [Planet's Python client](https://planetlabs.github.io/planet-client-python/index.html) to download the image. *Note: when you run this command, you'll get a stream of messages in your Jupyter notebook as the Python client polls the Data API to determine if the image is [activated and ready to download](https://planetlabs.github.io/planet-client-python/api/reference.html#activating-and-downloading-many-assets).*"
    ]
   },
   {
@@ -414,7 +414,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -428,7 +428,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/jupyter-notebooks/ndvi/ndvi_planetscope.ipynb
+++ b/jupyter-notebooks/ndvi/ndvi_planetscope.ipynb
@@ -49,7 +49,7 @@
    "source": [
     "### Requirements\n",
     "- Python 2.7 or 3+\n",
-    "- [Planet's Python Client](https://www.planet.com/docs/api-quickstart-examples/cli/)\n",
+    "- [Planet's Python Client](https://developers.planet.com/docs/planetschool/get-started-with-planet-cli-searching-for-data/)\n",
     "- [rasterio](https://github.com/mapbox/rasterio)\n",
     "- [numpy](http://www.numpy.org/)\n",
     "- [matplotlib](https://matplotlib.org/)\n",
@@ -68,9 +68,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First, you're going to download a [4-band PlanetScope satellite image](https://www.planet.com/docs/spec-sheets/sat-imagery/#ps-imagery-product) of agricultural land in California's Central Valley, captured in late August 2016 (`item-id`: `20160831_180302_0e26`). You can do this using [Planet's Python client](https://www.planet.com/docs/api-quickstart-examples/cli/) to interact with our Data API, or by browsing [Planet Explorer](https://www.planet.com/products/explorer/), filtering for 4 Band PlanetScope scene (`PSScene`) or Planetscope ortho tile (`PSOrthoTile`), and downloading an `ortho_analytic_4b` asset.\n",
+    "First, you're going to download a [4-band PlanetScope satellite image](https://www.planet.com/docs/spec-sheets/sat-imagery/#ps-imagery-product) of agricultural land in California's Central Valley, captured in late August 2016 (`item-id`: `20160831_180302_0e26`). You can do this using [Planet's Python client](https://developers.planet.com/docs/planetschool/get-started-with-planet-cli-searching-for-data/) to interact with our Data API, or by browsing [Planet Explorer](https://www.planet.com/products/explorer/), filtering for 4 Band PlanetScope scene (`PSScene`) or Planetscope ortho tile (`PSOrthoTile`), and downloading an `ortho_analytic_4b` asset.\n",
     "\n",
-    "Before you download the full image, you can [preview a thumbnail](https://www.planet.com/docs/reference/data-api/previews/) of the image via Planet's Data API. (The thumbnails are 256x256 by default, and can be scaled up to 512x512 by passing in a `width` parameter.) "
+    "Before you download the full image, you can [preview a thumbnail](https://developers.planet.com/docs/apis/data/item-previews/) of the image via Planet's Data API. (The thumbnails are 256x256 by default, and can be scaled up to 512x512 by passing in a `width` parameter.) "
    ]
   },
   {
@@ -1012,7 +1012,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1026,7 +1026,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/jupyter-notebooks/orders_api_tutorials/Planet_SDK_Orders_demo.ipynb
+++ b/jupyter-notebooks/orders_api_tutorials/Planet_SDK_Orders_demo.ipynb
@@ -19,7 +19,7 @@
    "source": [
     "## Authentication\n",
     "\n",
-    "The new SDK supports a couple different methods of authentication (and soon, will support OIDC / Okta token-based authentication as well). [Read more in the docs here](https://planet-sdk-for-python-v2.readthedocs.io/en/latest/api/#planet.auth.Auth).\n",
+    "The new SDK supports a couple different methods of authentication (and soon, will support OIDC / Okta token-based authentication as well). [Read more in the docs here](https://planet-sdk-for-python-v2.readthedocs.io/en/latest/python/sdk-guide/).\n",
     "\n",
     "For this example, I'll use the `getpass` tool to pass in my API key as a string to the `from_key` method."
    ]
@@ -107,7 +107,7 @@
    "source": [
     "### Method 2: New style\n",
     "\n",
-    "In V2 ofthe SDK, you can also build an Order request object using the new `order_request` functionality -- here you can specify all Order details including products, bundles & fallback bundles, cloud delivery configuration, tools & toolchain operations, etc. [Read more in the docs here](https://planet-sdk-for-python-v2.readthedocs.io/en/latest/api/#planet.order_request)."
+    "In V2 ofthe SDK, you can also build an Order request object using the new `order_request` functionality -- here you can specify all Order details including products, bundles & fallback bundles, cloud delivery configuration, tools & toolchain operations, etc. [Read more in the docs here](https://planet-sdk-for-python-v2.readthedocs.io/en/latest/python/sdk-guide/)."
    ]
   },
   {
@@ -214,7 +214,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -228,7 +228,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/jupyter-notebooks/orders_api_tutorials/tools_and_toolchains.ipynb
+++ b/jupyter-notebooks/orders_api_tutorials/tools_and_toolchains.ipynb
@@ -14,9 +14,9 @@
     " - [clip -> bandmath](#clip_bandmath)\n",
     " - [toar -> reproject -> tile](#toar_reproject_tile)\n",
     "\n",
-    "For background on ordering and downloading with the orders api, see the [Ordering and Delivery](https://github.com/planetlabs/notebooks/blob/master/jupyter-notebooks/orders/ordering_and_delivery.ipynb) notebook.\n",
+    "For background on ordering and downloading with the orders api, see the [Ordering and Delivery](https://github.com/planetlabs/notebooks/blob/master/jupyter-notebooks/orders_api_tutorials/ordering_and_delivery.ipynb) notebook.\n",
     "\n",
-    "Reference information can be found at [Tools & toolchains](https://developers.planet.com/docs/orders/tools-toolchains/).\n",
+    "Reference information can be found at [Tools & toolchains](https://developers.planet.com/apis/orders/tools/).\n",
     "\n",
     "## Setup"
    ]
@@ -759,7 +759,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/jupyter-notebooks/publish-to-arcgis-online/readme.md
+++ b/jupyter-notebooks/publish-to-arcgis-online/readme.md
@@ -17,5 +17,5 @@ These scripts specifically work with PlanetScope 8-band surface reflectance anal
 
 ### Multiple Notebook Versions
 
-* Planet to ArcGIS Image using SDKv2 - This notebook uses Planet's new Python SDK for faster and easier access to our API's.  In order to use this, you need to install the SDK: [How to install the Planet SDK for Python v2](https://planet-sdk-for-python-v2.readthedocs.io/en/latest/v2_earlyaccess/).
+* Planet to ArcGIS Image using SDKv2 - This notebook uses Planet's new Python SDK for faster and easier access to our API's.  In order to use this, you need to install the SDK: [How to install the Planet SDK for Python v2](https://planet-sdk-for-python-v2.readthedocs.io/en/latest/python/sdk-guide/).
 * Planet to ArcGIS Image using Requests - This notebook uses the python library Requests to make the API calls to Planet's platform.  It will work when run inside of ArcGIS Notebooks, a hosted Jupyter notebook in ArcGIS Online.

--- a/jupyter-notebooks/quad_tutorial/download_quads.ipynb
+++ b/jupyter-notebooks/quad_tutorial/download_quads.ipynb
@@ -289,7 +289,7 @@
     "---\n",
     "After a few simple steps, we now have a folder full of quads within our local directory. Check out our [Planet Basemaps API Documentation](https://developers.planet.com/docs/basemaps/reference/) to learn more. If you'd like to access the full .py script, follow this [link](download_quad.py).\n",
     "\n",
-    "Questions or comments about this guide? Join the conversation at [Planet Community](https://support.planet.com/hc/en-us/community/topics)."
+    "Questions or comments about this guide? Join the conversation at [Planet Community](https://community.planet.com/)."
    ]
   }
  ],
@@ -309,7 +309,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/jupyter-notebooks/toar/toar_planetscope.ipynb
+++ b/jupyter-notebooks/toar/toar_planetscope.ipynb
@@ -81,7 +81,7 @@
    "source": [
     "### Requirements\n",
     "- Python 2.7 or 3+\n",
-    "- [Planet's Python Client](https://www.planet.com/docs/api-quickstart-examples/cli/)\n",
+    "- [Planet's Python Client](https://developers.planet.com/docs/planetschool/get-started-with-planet-cli-searching-for-data/?gclid=Cj0KCQiAm5ycBhCXARIsAPldzoVlBOXsJmHIoIONSs9ayCr9j6dAEHFHVs641uk1yX_CkeQWsP4AM7caAtddEALw_wcB)\n",
     "- [rasterio](https://github.com/mapbox/rasterio)\n",
     "- [numpy](http://www.numpy.org/)\n",
     "- [matplotlib](https://matplotlib.org/)\n",
@@ -100,9 +100,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First, you're going to download a [4-band PlanetScope satellite image](https://developers.planet.com/docs/data/psscene/) of agricultural land in California's Central Valley, captured in mid July 2017 (`item-id`: `20170623_180038_0f34`). You can do this using [Planet's Python client](https://www.planet.com/docs/api-quickstart-examples/cli/) to interact with our Data API, or by browsing [Planet Explorer](https://www.planet.com/products/explorer/), filtering for 4 Band PlanetScope scene (`PSScene`) or Planetscope ortho tile (`PSOrthoTile`), and downloading an `ortho_analytic_4b` asset.\n",
+    "First, you're going to download a [4-band PlanetScope satellite image](https://developers.planet.com/docs/data/psscene/) of agricultural land in California's Central Valley, captured in mid July 2017 (`item-id`: `20170623_180038_0f34`). You can do this using [Planet's Python client](https://developers.planet.com/docs/planetschool/get-started-with-planet-cli-searching-for-data/?gclid=Cj0KCQiAm5ycBhCXARIsAPldzoVlBOXsJmHIoIONSs9ayCr9j6dAEHFHVs641uk1yX_CkeQWsP4AM7caAtddEALw_wcB) to interact with our Data API, or by browsing [Planet Explorer](https://www.planet.com/products/explorer/), filtering for 4 Band PlanetScope scene (`PSScene`) or Planetscope ortho tile (`PSOrthoTile`), and downloading an `ortho_analytic_4b` asset.\n",
     "\n",
-    "Before you download the full image, you can [preview a thumbnail](https://www.planet.com/docs/reference/data-api/previews/) of the image via Planet's Data API. (The thumbnails are 256x256 by default, and can be scaled up by passing in a `width` parameter.) "
+    "Before you download the full image, you can [preview a thumbnail](https://developers.planet.com/docs/apis/data/item-previews/) of the image via Planet's Data API. (The thumbnails are 256x256 by default, and can be scaled up by passing in a `width` parameter.) "
    ]
   },
   {
@@ -664,7 +664,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/jupyter-notebooks/udm2/udm2.ipynb
+++ b/jupyter-notebooks/udm2/udm2.ipynb
@@ -455,7 +455,7 @@
    "source": [
     "### Visualize UDM2 Unusable Data Mask Band\n",
     "\n",
-    "The Unusable Data Mask band of the UDM2 is the original UDM. It is a bit-encoded representation of whether a pixel is usable and, if not, why. Let's check out the usability of the pixels in this image. This section pulls functionality from the [UDM notebook](udm.ipynb)."
+    "The Unusable Data Mask band of the UDM2 is the original UDM. It is a bit-encoded representation of whether a pixel is usable and, if not, why. Let's check out the usability of the pixels in this image. This section pulls functionality from the [UDM notebook](../udm/udm.ipynb)."
    ]
   },
   {
@@ -612,7 +612,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/jupyter-notebooks/udm2/udm2_clouds_aoi.ipynb
+++ b/jupyter-notebooks/udm2/udm2_clouds_aoi.ipynb
@@ -69,7 +69,7 @@
    "source": [
     "## Finding clear imagery\n",
     "\n",
-    "One of the benefits of accurate and automated cloud detection is that it allows users to filter out images that don't meet a certain quality threshold. Planet's Data API allows users to [search](https://developers.planet.com/docs/api/searches-filtering/) based on the value of the imagery metadata.\n",
+    "One of the benefits of accurate and automated cloud detection is that it allows users to filter out images that don't meet a certain quality threshold. Planet's Data API allows users to [search](https://developers.planet.com/docs/apis/data/searches-filtering/) based on the value of the imagery metadata.\n",
     "    \n",
     "Planet's cloud detection algorithm classifies every pixel into one of six different categories, each of which has a corresponding metadata field that reflects the percentage of data that falls into the category.\n",
     "\n",
@@ -412,7 +412,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/jupyter-notebooks/water_change/water-level-changes-notebook/calculate_changes.ipynb
+++ b/jupyter-notebooks/water_change/water-level-changes-notebook/calculate_changes.ipynb
@@ -406,13 +406,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Questions or comments about this guide? Join the conversation at [Planet Community](https://support.planet.com/hc/en-us/community/topics)."
+    "Questions or comments about this guide? Join the conversation at [Planet Community](https://community.planet.com/)."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -426,7 +433,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,

--- a/jupyter-notebooks/webtiles/osm_basemap.ipynb
+++ b/jupyter-notebooks/webtiles/osm_basemap.ipynb
@@ -35,7 +35,7 @@
    "source": [
     "## Selecting a Tileset\n",
     "\n",
-    "Cartopy supports many common tile servers, listed on https://scitools.org.uk/cartopy/docs/latest/cartopy/io/img_tiles.html\n",
+    "Cartopy supports many common tile servers, listed on https://github.com/SciTools/cartopy/releases\n",
     "\n",
     "For this example, we will use OSM."
    ]
@@ -58,7 +58,7 @@
     "\n",
     "### Projection\n",
     "\n",
-    "Can define your own https://scitools.org.uk/cartopy/docs/latest/crs/index.html or use one of the constant values.\n",
+    "Can define your own https://github.com/SciTools/cartopy/releases or use one of the constant values.\n",
     "We will use Google Mercator for this example"
    ]
   },
@@ -1714,7 +1714,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1728,7 +1728,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.9.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This update fixes many different broken links on notebooks. Some links are still broken because they are not able to be fixed right now either due to lack of information or legacy products. Some of these include data that no longer works in the crop classification notebook, a missing data folder in the convert radiance to reflectance notebook, and multiple notebooks specifically the ship detector notebook that still use references to "clip and ship" which is a tool no longer used at Planet. 