### PR TITLE
update asset download section in Data API Intro Ntbk to use client DEVREL-927

### DIFF
--- a/jupyter-notebooks/data-api-tutorials/planet_python_client_introduction.ipynb
+++ b/jupyter-notebooks/data-api-tutorials/planet_python_client_introduction.ipynb
@@ -109,7 +109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -160,7 +160,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "metadata": {
     "scrolled": true
    },
@@ -192,7 +192,7 @@
        "  {'type': 'RangeFilter', 'field_name': 'cloud_cover', 'config': {'lt': 0.1}}]}"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -210,7 +210,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -221,16 +221,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "{'__daily_email_enabled': False,\n",
-       " '_links': {'_self': 'https://api.planet.com/data/v1/searches/1062d39a760c44a0b9f0a22f14070e7b',\n",
-       "  'results': 'https://api.planet.com/data/v1/searches/1062d39a760c44a0b9f0a22f14070e7b/results'},\n",
-       " 'created': '2022-12-09T20:35:54.228165Z',\n",
+       " '_links': {'_self': 'https://api.planet.com/data/v1/searches/d4a97c06516447a186fbf5c3c0dc44b2',\n",
+       "  'results': 'https://api.planet.com/data/v1/searches/d4a97c06516447a186fbf5c3c0dc44b2/results'},\n",
+       " 'created': '2022-12-11T23:34:26.955332Z',\n",
        " 'filter': {'config': [{'config': {'coordinates': [[[-122.47455596923828,\n",
        "        37.810326435534755],\n",
        "       [-122.49172210693358, 37.795406713958236],\n",
@@ -258,15 +258,15 @@
        "    'field_name': 'cloud_cover',\n",
        "    'type': 'RangeFilter'}],\n",
        "  'type': 'AndFilter'},\n",
-       " 'id': '1062d39a760c44a0b9f0a22f14070e7b',\n",
+       " 'id': 'd4a97c06516447a186fbf5c3c0dc44b2',\n",
        " 'item_types': ['REOrthoTile', 'PSOrthoTile'],\n",
        " 'last_executed': None,\n",
        " 'name': 'planet_client_demo',\n",
        " 'search_type': 'saved',\n",
-       " 'updated': '2022-12-09T20:35:54.228165Z'}"
+       " 'updated': '2022-12-11T23:34:26.955332Z'}"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -277,12 +277,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Search the Data API\n",
-    "# The default result limit is 100. Here, we're setting our limit to 50\n",
+    "\n",
+    "# The limit paramter allows us to limit the number of results from our search that are returned.\n",
+    "# The default limit is 100. Here, we're setting our result limit to 50.\n",
     "async with Session() as sess:\n",
     "    cl = DataClient(sess)\n",
     "    items = await cl.run_search(search_id=request['id'], limit=50)\n",
@@ -298,7 +300,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 10,
    "metadata": {
     "scrolled": true
    },
@@ -374,7 +376,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -401,12 +403,12 @@
     "\n",
     "After a search returns results, the Python client can be used to check for assets and initiate downloads. Let's start by looking at one item and the assets available to download for that item.\n",
     "\n",
-    "For more information and Assets and Items, check out [Items & Assets](https://developers.planet.com/docs/apis/data/items-assets/) on the Planet Developer Center."
+    "For more information on Items and Assets, check out [Items & Assets](https://developers.planet.com/docs/apis/data/items-assets/) on the Planet Developer Center."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -426,7 +428,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -445,7 +447,7 @@
        " 'assets.visual_xml:download']"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -457,7 +459,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -473,7 +475,7 @@
    "source": [
     "There are a few steps involved in order to download an asset using the Planet Python Client:\n",
     "\n",
-    "* **Get Asset:** Get a desscription of our asset based on the specifications we're looking for\n",
+    "* **Get Asset:** Get a description of our asset based on the specifications we're looking for\n",
     "* **Activate Asset:** Activate the asset with the given description\n",
     "* **Wait Asset:** Wait for the asset to be activated\n",
     "* **Download Asset:** Now our asset is ready for download!\n",
@@ -483,14 +485,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "output/6128289_1056417_2022-12-07_2262_BGRN_Analytic.tif: 100%|█| 416k/416k [03:08<00:00, 2.31M\n"
+      "output/6128289_1056417_2022-12-07_2262_BGRN_Analytic.tif: 100%|█| 416k/416k [02:30<00:00, 2.90M\n"
      ]
     }
    ],
@@ -510,7 +512,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -539,7 +541,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Congratulations! Both the analytic and analytic_xml assets should be saved in our outputs directory."
+    "Congratulations! Both the `analytic` and `analytic_xml` assets should be saved in our `output` directory."
    ]
   },
   {
@@ -548,12 +550,12 @@
    "source": [
     "## Saved Searches\n",
     "\n",
-    "The Python API client can also help in managing saved searches on the Planet Platform."
+    "The Data API client can also help in managing saved searches on the Planet Platform."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -565,7 +567,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -574,7 +576,7 @@
        "100"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -589,12 +591,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "View your saved searches:"
+    "View your saved searches. Here we're viewing our first 50 results."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 19,
    "metadata": {
     "scrolled": true
    },
@@ -603,6 +605,28 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "d4a97c06516447a186fbf5c3c0dc44b2 planet_client_demo\n",
+      "adc6919d38b14b43af0b2dc31022d3b9 adc6919d38b14b43af0b2dc31022d3b9\n",
+      "a5eec1b249454480adcfbc3b589e98c8 a5eec1b249454480adcfbc3b589e98c8\n",
+      "9c64da27e5024125972695357f83d039 9c64da27e5024125972695357f83d039\n",
+      "a3061cc16b2d4c8e9ccb878e445e979e a3061cc16b2d4c8e9ccb878e445e979e\n",
+      "a01f7281acbe437fabfbd04db1260277 a01f7281acbe437fabfbd04db1260277\n",
+      "8bff651293b3463cbc26da367b3d94af 8bff651293b3463cbc26da367b3d94af\n",
+      "1843e230394640259b4f5215ca76d204 1843e230394640259b4f5215ca76d204\n",
+      "5d1c500abea84ad385f64137bc0a1dcb 5d1c500abea84ad385f64137bc0a1dcb\n",
+      "16544d51afe5460d9cd8a4104cb2ec39 16544d51afe5460d9cd8a4104cb2ec39\n",
+      "a46b59a843f7424186e20e17dbfa18cc a46b59a843f7424186e20e17dbfa18cc\n",
+      "d7ca149c8a614b42af83059ea9f5a924 d7ca149c8a614b42af83059ea9f5a924\n",
+      "78dc94248a704c34826cf71a007021bf 78dc94248a704c34826cf71a007021bf\n",
+      "5179d7384cce44fdb6fbe269d21058af 5179d7384cce44fdb6fbe269d21058af\n",
+      "a1006ce940d54045bfefc5374b411e36 a1006ce940d54045bfefc5374b411e36\n",
+      "0c10abb0859c4659a1a5e0ea9e32e1dd 0c10abb0859c4659a1a5e0ea9e32e1dd\n",
+      "c9e49b8c33054ae6bc4c033cac239e38 c9e49b8c33054ae6bc4c033cac239e38\n",
+      "eded222eda004fe2937b0659adf33b03 eded222eda004fe2937b0659adf33b03\n",
+      "bb14d4ee481e494ea0bb760c1b042f4d bb14d4ee481e494ea0bb760c1b042f4d\n",
+      "a990276f3baa4a6b88040f95f9026ac4 a990276f3baa4a6b88040f95f9026ac4\n",
+      "44d16b3acc064e949eaad7908bfe4cee 44d16b3acc064e949eaad7908bfe4cee\n",
+      "7b782b1ebd554463a5032351c448995b 7b782b1ebd554463a5032351c448995b\n",
       "1062d39a760c44a0b9f0a22f14070e7b planet_client_demo\n",
       "f5dfc1298e1249848ac99df4e981c1e3 planet_client_demo\n",
       "43dca6cff2944a239d96b4b39263c464 43dca6cff2944a239d96b4b39263c464\n",
@@ -630,29 +654,7 @@
       "e3bb009793874083b26009377cac0144 e3bb009793874083b26009377cac0144\n",
       "5c6c6d24cbe84bfe9554904f86d78ad9 5c6c6d24cbe84bfe9554904f86d78ad9\n",
       "09724372370e401185ee7b222f0afaed 09724372370e401185ee7b222f0afaed\n",
-      "aecd3bd679f9493c89edf75524b58088 aecd3bd679f9493c89edf75524b58088\n",
-      "59e40eef01a8413aa4e174b48bacd544 59e40eef01a8413aa4e174b48bacd544\n",
-      "a9d4d04c8eb843f5a2c9e14b1fc45ec2 a9d4d04c8eb843f5a2c9e14b1fc45ec2\n",
-      "de16da55282a488c8837c74c88f2592b de16da55282a488c8837c74c88f2592b\n",
-      "02d608d08a1b4909aa730f790bdfee86 02d608d08a1b4909aa730f790bdfee86\n",
-      "837321f261514779ba0fb3d80951a7ea 837321f261514779ba0fb3d80951a7ea\n",
-      "6720029d6069444799d5a635add0d38e 6720029d6069444799d5a635add0d38e\n",
-      "15243508e5134a29bf121e1d1986898a 15243508e5134a29bf121e1d1986898a\n",
-      "9cd459b4012e41a885d84868ea2c1e31 9cd459b4012e41a885d84868ea2c1e31\n",
-      "d190e0cdcdff43ee843d9f1a1130a873 d190e0cdcdff43ee843d9f1a1130a873\n",
-      "c93690c25bea4ca3b09d22a833a4e12f c93690c25bea4ca3b09d22a833a4e12f\n",
-      "5b90fbb15e9a478ba616728300885c8e 5b90fbb15e9a478ba616728300885c8e\n",
-      "25dbda59f3c0462caad3005c15c613dc 25dbda59f3c0462caad3005c15c613dc\n",
-      "efd4bc43a1f14ea5904469eede1e1575 efd4bc43a1f14ea5904469eede1e1575\n",
-      "0aa12b11b2bf4b51a787013a958ef1fe 0aa12b11b2bf4b51a787013a958ef1fe\n",
-      "348aaf1cf2204b7ab0643c9a95ba24f0 348aaf1cf2204b7ab0643c9a95ba24f0\n",
-      "773d5129097a4282903a13f3a47edb9e 773d5129097a4282903a13f3a47edb9e\n",
-      "5c1b159db56f41af8b3d9af374af2bdc 5c1b159db56f41af8b3d9af374af2bdc\n",
-      "560dc1f66ab44e9b8ac2499f224dc1cc 560dc1f66ab44e9b8ac2499f224dc1cc\n",
-      "aae5f71061bd4f569f23ea49bdf32883 aae5f71061bd4f569f23ea49bdf32883\n",
-      "58c0f350d2dd4b0b9935705b34fd6eca 58c0f350d2dd4b0b9935705b34fd6eca\n",
-      "36e3eaa300d14fe7a292ff5f8041bd18 36e3eaa300d14fe7a292ff5f8041bd18\n",
-      "a6a451a385064e18b40e098344c70eba a6a451a385064e18b40e098344c70eba\n"
+      "aecd3bd679f9493c89edf75524b58088 aecd3bd679f9493c89edf75524b58088\n"
      ]
     }
    ],
@@ -670,7 +672,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -681,16 +683,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "{'__daily_email_enabled': False,\n",
-       " '_links': {'_self': 'https://api.planet.com/data/v1/searches/1062d39a760c44a0b9f0a22f14070e7b',\n",
-       "  'results': 'https://api.planet.com/data/v1/searches/1062d39a760c44a0b9f0a22f14070e7b/results'},\n",
-       " 'created': '2022-12-09T20:35:54.228165Z',\n",
+       " '_links': {'_self': 'https://api.planet.com/data/v1/searches/d4a97c06516447a186fbf5c3c0dc44b2',\n",
+       "  'results': 'https://api.planet.com/data/v1/searches/d4a97c06516447a186fbf5c3c0dc44b2/results'},\n",
+       " 'created': '2022-12-11T23:34:26.955332Z',\n",
        " 'filter': {'config': [{'config': {'coordinates': [[[-122.47455596923828,\n",
        "        37.810326435534755],\n",
        "       [-122.49172210693358, 37.795406713958236],\n",
@@ -718,15 +720,15 @@
        "    'field_name': 'cloud_cover',\n",
        "    'type': 'RangeFilter'}],\n",
        "  'type': 'AndFilter'},\n",
-       " 'id': '1062d39a760c44a0b9f0a22f14070e7b',\n",
+       " 'id': 'd4a97c06516447a186fbf5c3c0dc44b2',\n",
        " 'item_types': ['REOrthoTile', 'PSOrthoTile'],\n",
-       " 'last_executed': '2022-12-09T20:36:09.504776Z',\n",
+       " 'last_executed': '2022-12-11T23:34:27.230620Z',\n",
        " 'name': 'planet_client_demo',\n",
        " 'search_type': 'saved',\n",
-       " 'updated': '2022-12-09T20:36:09.505035Z'}"
+       " 'updated': '2022-12-11T23:34:27.230938Z'}"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -741,12 +743,12 @@
    "source": [
     "# Statistics\n",
     "\n",
-    "The Python API client can also help report statistical summaries of the amount of data in the Planet API."
+    "The Data API client can also help report statistical summaries of the amount of data in the Planet API."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -759,7 +761,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 23,
    "metadata": {
     "scrolled": true
    },

--- a/jupyter-notebooks/data-api-tutorials/planet_python_client_introduction.ipynb
+++ b/jupyter-notebooks/data-api-tutorials/planet_python_client_introduction.ipynb
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -109,7 +109,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,7 +142,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -160,13 +160,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'type': 'AndFilter',\n",
+       " 'config': [{'type': 'GeometryFilter',\n",
+       "   'field_name': 'geometry',\n",
+       "   'config': {'type': 'Polygon',\n",
+       "    'coordinates': [[[-122.47455596923828, 37.810326435534755],\n",
+       "      [-122.49172210693358, 37.795406713958236],\n",
+       "      [-122.52056121826172, 37.784282779035216],\n",
+       "      [-122.51953124999999, 37.6971326434885],\n",
+       "      [-122.38941192626953, 37.69441603823106],\n",
+       "      [-122.38872528076173, 37.705010235842614],\n",
+       "      [-122.36228942871092, 37.70935613533687],\n",
+       "      [-122.34992980957031, 37.727280276860036],\n",
+       "      [-122.37773895263672, 37.76230130281876],\n",
+       "      [-122.38494873046875, 37.794592824285104],\n",
+       "      [-122.40554809570311, 37.813310018173155],\n",
+       "      [-122.46150970458983, 37.805715207044685],\n",
+       "      [-122.47455596923828, 37.810326435534755]]]}},\n",
+       "  {'type': 'RangeFilter', 'field_name': 'clear_percent', 'config': {'gt': 90}},\n",
+       "  {'type': 'DateRangeFilter',\n",
+       "   'field_name': 'acquired',\n",
+       "   'config': {'gt': '2017-01-01T00:00:00Z'}},\n",
+       "  {'type': 'RangeFilter', 'field_name': 'cloud_cover', 'config': {'lt': 0.1}}]}"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "indent(combined_filter)"
+    "combined_filter"
    ]
   },
   {
@@ -178,7 +210,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -189,23 +221,71 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'__daily_email_enabled': False,\n",
+       " '_links': {'_self': 'https://api.planet.com/data/v1/searches/1062d39a760c44a0b9f0a22f14070e7b',\n",
+       "  'results': 'https://api.planet.com/data/v1/searches/1062d39a760c44a0b9f0a22f14070e7b/results'},\n",
+       " 'created': '2022-12-09T20:35:54.228165Z',\n",
+       " 'filter': {'config': [{'config': {'coordinates': [[[-122.47455596923828,\n",
+       "        37.810326435534755],\n",
+       "       [-122.49172210693358, 37.795406713958236],\n",
+       "       [-122.52056121826172, 37.784282779035216],\n",
+       "       [-122.51953124999999, 37.6971326434885],\n",
+       "       [-122.38941192626953, 37.69441603823106],\n",
+       "       [-122.38872528076173, 37.705010235842614],\n",
+       "       [-122.36228942871092, 37.70935613533687],\n",
+       "       [-122.34992980957031, 37.727280276860036],\n",
+       "       [-122.37773895263672, 37.76230130281876],\n",
+       "       [-122.38494873046875, 37.794592824285104],\n",
+       "       [-122.40554809570311, 37.813310018173155],\n",
+       "       [-122.46150970458983, 37.805715207044685],\n",
+       "       [-122.47455596923828, 37.810326435534755]]],\n",
+       "     'type': 'Polygon'},\n",
+       "    'field_name': 'geometry',\n",
+       "    'type': 'GeometryFilter'},\n",
+       "   {'config': {'gt': 90.0},\n",
+       "    'field_name': 'clear_percent',\n",
+       "    'type': 'RangeFilter'},\n",
+       "   {'config': {'gt': '2017-01-01T00:00:00Z'},\n",
+       "    'field_name': 'acquired',\n",
+       "    'type': 'DateRangeFilter'},\n",
+       "   {'config': {'lt': 0.1},\n",
+       "    'field_name': 'cloud_cover',\n",
+       "    'type': 'RangeFilter'}],\n",
+       "  'type': 'AndFilter'},\n",
+       " 'id': '1062d39a760c44a0b9f0a22f14070e7b',\n",
+       " 'item_types': ['REOrthoTile', 'PSOrthoTile'],\n",
+       " 'last_executed': None,\n",
+       " 'name': 'planet_client_demo',\n",
+       " 'search_type': 'saved',\n",
+       " 'updated': '2022-12-09T20:35:54.228165Z'}"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "indent(request)"
+    "request"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Search the Data API\n",
+    "# The default result limit is 100. Here, we're setting our limit to 50\n",
     "async with Session() as sess:\n",
     "    cl = DataClient(sess)\n",
-    "    items = await cl.run_search(search_id=request['id'])\n",
+    "    items = await cl.run_search(search_id=request['id'], limit=50)\n",
     "    item_list = [i async for i in items]"
    ]
   },
@@ -218,11 +298,68 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6128289_1056417_2022-12-07_2262 PSOrthoTile\n",
+      "6117841_1056517_2022-12-02_247f PSOrthoTile\n",
+      "6117841_1056516_2022-12-02_247f PSOrthoTile\n",
+      "6117841_1056417_2022-12-02_247f PSOrthoTile\n",
+      "6117841_1056416_2022-12-02_247f PSOrthoTile\n",
+      "6117149_1056517_2022-12-02_2430 PSOrthoTile\n",
+      "6117149_1056516_2022-12-02_2430 PSOrthoTile\n",
+      "6104170_1056517_2022-11-26_2423 PSOrthoTile\n",
+      "6104170_1056417_2022-11-26_2423 PSOrthoTile\n",
+      "6099543_1056517_2022-11-24_242d PSOrthoTile\n",
+      "6099543_1056417_2022-11-24_242d PSOrthoTile\n",
+      "6095810_1056416_2022-11-22_249a PSOrthoTile\n",
+      "6095810_1056517_2022-11-22_249a PSOrthoTile\n",
+      "6095810_1056516_2022-11-22_249a PSOrthoTile\n",
+      "6095810_1056417_2022-11-22_249a PSOrthoTile\n",
+      "6093412_1056516_2022-11-21_2430 PSOrthoTile\n",
+      "6093412_1056517_2022-11-21_2430 PSOrthoTile\n",
+      "6093412_1056417_2022-11-21_2430 PSOrthoTile\n",
+      "6093412_1056416_2022-11-21_2430 PSOrthoTile\n",
+      "6089131_1056517_2022-11-19_2465 PSOrthoTile\n",
+      "6089131_1056516_2022-11-19_2465 PSOrthoTile\n",
+      "6089131_1056417_2022-11-19_2465 PSOrthoTile\n",
+      "6089131_1056416_2022-11-19_2465 PSOrthoTile\n",
+      "6082627_1056417_2022-11-16_247b PSOrthoTile\n",
+      "6082627_1056517_2022-11-16_247b PSOrthoTile\n",
+      "6082627_1056516_2022-11-16_247b PSOrthoTile\n",
+      "6076119_1056517_2022-11-13_242d PSOrthoTile\n",
+      "6076119_1056516_2022-11-13_242d PSOrthoTile\n",
+      "6067219_1056517_2022-11-09_249d PSOrthoTile\n",
+      "6067219_1056516_2022-11-09_249d PSOrthoTile\n",
+      "6060194_1056517_2022-11-06_247d PSOrthoTile\n",
+      "6054452_1056417_2022-11-03_247f PSOrthoTile\n",
+      "6054452_1056517_2022-11-03_247f PSOrthoTile\n",
+      "6053688_1056516_2022-11-03_2481 PSOrthoTile\n",
+      "6041960_1056517_2022-10-29_2416 PSOrthoTile\n",
+      "6041960_1056417_2022-10-29_2416 PSOrthoTile\n",
+      "6034926_1056516_2022-10-26_241d PSOrthoTile\n",
+      "6032365_1056517_2022-10-25_2455 PSOrthoTile\n",
+      "6030099_1056517_2022-10-24_2446 PSOrthoTile\n",
+      "6030099_1056417_2022-10-24_2446 PSOrthoTile\n",
+      "6030099_1056416_2022-10-24_2446 PSOrthoTile\n",
+      "6020789_1056517_2022-10-20_248b PSOrthoTile\n",
+      "6020789_1056516_2022-10-20_248b PSOrthoTile\n",
+      "6018646_1056517_2022-10-18_2402 PSOrthoTile\n",
+      "6018550_1056517_2022-10-19_2445 PSOrthoTile\n",
+      "6018550_1056516_2022-10-19_2445 PSOrthoTile\n",
+      "5976834_1056517_2022-10-03_2431 PSOrthoTile\n",
+      "5976834_1056417_2022-10-03_2431 PSOrthoTile\n",
+      "5968672_1056517_2022-09-30_2485 PSOrthoTile\n",
+      "5964618_1056516_2022-09-29_2465 PSOrthoTile\n"
+     ]
+    }
+   ],
    "source": [
     "for item in item_list:\n",
     "    print(item['id'], item['properties']['item_type'])"
@@ -237,7 +374,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -262,140 +399,147 @@
    "source": [
     "## Assets and downloads\n",
     "\n",
-    "After a search returns results, the Python client can be used to check for assets and initiate downloads.\n",
+    "After a search returns results, the Python client can be used to check for assets and initiate downloads. Let's start by looking at one item and the assets available to download for that item.\n",
     "\n",
-    "The list of assets for an item that a user has access to can be retrieved with `permissions`"
+    "For more information and Assets and Items, check out [Items & Assets](https://developers.planet.com/docs/apis/data/items-assets/) on the Planet Developer Center."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [],
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6128289_1056417_2022-12-07_2262 PSOrthoTile\n"
+     ]
+    }
+   ],
    "source": [
-    "print(item['id'])"
+    "# As an example, let's look at the first result in our item_list and grab the item_id and item_type:\n",
+    "item = item_list[0]\n",
+    "\n",
+    "print(item['id'], item['properties']['item_type'])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['assets.analytic:download',\n",
+       " 'assets.analytic_5b:download',\n",
+       " 'assets.analytic_5b_xml:download',\n",
+       " 'assets.analytic_dn:download',\n",
+       " 'assets.analytic_dn_xml:download',\n",
+       " 'assets.analytic_sr:download',\n",
+       " 'assets.analytic_xml:download',\n",
+       " 'assets.udm:download',\n",
+       " 'assets.udm2:download',\n",
+       " 'assets.visual:download',\n",
+       " 'assets.visual_xml:download']"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
+    "# The list of assets for an item that a user has access to can be retrieved with `permissions`\n",
     "item['_permissions']"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Get the assets link for the item\n",
-    "assets_url = item[\"_links\"][\"assets\"]\n",
+    "# Define our item_id, and item_type\n",
     "\n",
-    "# Print the assets link\n",
-    "print(assets_url)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Send a GET request to the assets url for the item (Get the list of available assets for the item)\n",
-    "res = session.get(assets_url)\n",
-    "\n",
-    "# Assign a variable to the response\n",
-    "assets = res.json()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "# Assign a variable to the analytic asset from the item's assets\n",
-    "analytic_asset = assets[\"analytic\"]\n",
-    "\n",
-    "# Print the analytic asset data\n",
-    "indent(analytic_asset)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Setup the activation url for a particular asset (in this case an analytic asset)\n",
-    "activation_url = analytic_asset[\"_links\"][\"activate\"]\n",
-    "\n",
-    "# Send a request to the activation url to activate the item\n",
-    "res = session.get(activation_url)\n",
-    "\n",
-    "# Print the response from the activation request\n",
-    "p(res.status_code)"
+    "item_id = item['id']\n",
+    "item_type = item['properties']['item_type']"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A response of 202 means that the request has been accepted and the activation will begin shortly. A 204 code indicates that the asset is already active and no further action is needed. A 401 code means the user does not have permissions to download this file.\n",
+    "There are a few steps involved in order to download an asset using the Planet Python Client:\n",
     "\n",
-    "Below, we are polling the API until the item is done activation. This may take awhile."
+    "* **Get Asset:** Get a desscription of our asset based on the specifications we're looking for\n",
+    "* **Activate Asset:** Activate the asset with the given description\n",
+    "* **Wait Asset:** Wait for the asset to be activated\n",
+    "* **Download Asset:** Now our asset is ready for download!\n",
+    "\n",
+    "Let's go through these steps below. We'll do this for our analytic asset, as well as the analytic_xml asset."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
-   "outputs": [],
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "output/6128289_1056417_2022-12-07_2262_BGRN_Analytic.tif: 100%|█| 416k/416k [03:08<00:00, 2.31M\n"
+     ]
+    }
+   ],
    "source": [
-    "asset_activated = False\n",
-    "\n",
-    "while asset_activated == False:\n",
-    "    # Send a request to the item's assets url\n",
-    "    res = session.get(assets_url)\n",
-    "\n",
-    "    # Assign a variable to the item's assets url response\n",
-    "    assets = res.json()\n",
-    "\n",
-    "    asset_status = analytic_asset[\"status\"]\n",
-    "    print(asset_status)\n",
-    "    time.sleep(15) \n",
-    "    \n",
-    "    # If asset is already active, we are done\n",
-    "    if asset_status == 'active':\n",
-    "        asset_activated = True\n",
-    "        print(\"Asset is active and ready to download\")\n",
-    "\n",
-    "# Print the analytic asset data    \n",
-    "indent(analytic_asset)"
+    "# Analytic Asset\n",
+    "async with Session() as sess:\n",
+    "    cl = DataClient(sess)\n",
+    "    # Get Asset\n",
+    "    asset_desc = await cl.get_asset(item_type_id=item_type,item_id=item_id, asset_type_id='analytic')\n",
+    "    # Activate Asset\n",
+    "    await cl.activate_asset(asset=asset_desc)\n",
+    "    # Wait Asset\n",
+    "    await cl.wait_asset(asset=asset_desc)\n",
+    "    # Download Asset\n",
+    "    asset_path = await cl.download_asset(asset=asset_desc, directory='output', overwrite=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [],
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "output/6128289_1056417_2022-12-07_2262_BGRN_Analytic_metadata.xml: 100%|█| 0.01k/0.01k [00:00<0\n"
+     ]
+    }
+   ],
    "source": [
-    "callback = api.write_to_file(directory='output/')\n",
-    "body = client.download(assets['analytic_xml'], callback=callback)\n",
-    "print(body)"
+    "# Analytic XML Asset\n",
+    "async with Session() as sess:\n",
+    "    cl = DataClient(sess)\n",
+    "    # Get Asset\n",
+    "    asset_desc = await cl.get_asset(item_type_id=item_type,item_id=item_id, asset_type_id='analytic_xml')\n",
+    "    # Activate Asset\n",
+    "    await cl.activate_asset(asset=asset_desc)\n",
+    "    # Wait Asset (this may take some time!)\n",
+    "    await cl.wait_asset(asset=asset_desc)\n",
+    "    # Download Asset\n",
+    "    asset_path = await cl.download_asset(asset=asset_desc, directory='output', overwrite=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Congratulations! Both the analytic and analytic_xml assets should be saved in our outputs directory."
    ]
   },
   {
@@ -409,7 +553,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -421,9 +565,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "100"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# We may have a lot of saved searches!\n",
     "\n",
@@ -439,13 +594,70 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1062d39a760c44a0b9f0a22f14070e7b planet_client_demo\n",
+      "f5dfc1298e1249848ac99df4e981c1e3 planet_client_demo\n",
+      "43dca6cff2944a239d96b4b39263c464 43dca6cff2944a239d96b4b39263c464\n",
+      "816d88e6e2ab4719abd0df7fd1403fb7 816d88e6e2ab4719abd0df7fd1403fb7\n",
+      "0e5c694738fa472ca365e91828bbff9c 0e5c694738fa472ca365e91828bbff9c\n",
+      "84fd57c2549d4658bdb60b2478f93528 84fd57c2549d4658bdb60b2478f93528\n",
+      "682f64d5f0304ea08103689919740354 682f64d5f0304ea08103689919740354\n",
+      "22568456f1cc4c69a80cb0121b1271bf 22568456f1cc4c69a80cb0121b1271bf\n",
+      "1dbd454ee3c54ff4ae457a8f136fd642 1dbd454ee3c54ff4ae457a8f136fd642\n",
+      "fb73db3ee010410e81cdbd39c1355ce1 fb73db3ee010410e81cdbd39c1355ce1\n",
+      "0f1d6706b8d14f7896477a6df6409c47 0f1d6706b8d14f7896477a6df6409c47\n",
+      "aff65930c69b4c818c778e2e87ae4b84 aff65930c69b4c818c778e2e87ae4b84\n",
+      "d5e28fe0154944d98317cc19fff4c594 d5e28fe0154944d98317cc19fff4c594\n",
+      "4a01df80dce443199e902b023e30b17c 4a01df80dce443199e902b023e30b17c\n",
+      "6df9c275d6a2448c821f9d395a91ce2e 6df9c275d6a2448c821f9d395a91ce2e\n",
+      "f0dd5a03dd5b48d0ad8538fd0d044c51 f0dd5a03dd5b48d0ad8538fd0d044c51\n",
+      "14f0f4bdf11a41658510a5b847e339a2 14f0f4bdf11a41658510a5b847e339a2\n",
+      "0b18f4b6f4a345d4bc3b3945cf0f1a2c 0b18f4b6f4a345d4bc3b3945cf0f1a2c\n",
+      "ce061eff824f4a29becea68a602be9d5 ce061eff824f4a29becea68a602be9d5\n",
+      "aabe3f61782647f2915999ffbed51cd0 aabe3f61782647f2915999ffbed51cd0\n",
+      "f804ec44a2ac4efeb9db96e3180a2d56 f804ec44a2ac4efeb9db96e3180a2d56\n",
+      "9e5c0551c2284a929119167b06265ead 9e5c0551c2284a929119167b06265ead\n",
+      "aa407320798844068f9342552b7e2304 aa407320798844068f9342552b7e2304\n",
+      "afcd6ea0243146d089e70db8e273a657 afcd6ea0243146d089e70db8e273a657\n",
+      "e3bb009793874083b26009377cac0144 e3bb009793874083b26009377cac0144\n",
+      "5c6c6d24cbe84bfe9554904f86d78ad9 5c6c6d24cbe84bfe9554904f86d78ad9\n",
+      "09724372370e401185ee7b222f0afaed 09724372370e401185ee7b222f0afaed\n",
+      "aecd3bd679f9493c89edf75524b58088 aecd3bd679f9493c89edf75524b58088\n",
+      "59e40eef01a8413aa4e174b48bacd544 59e40eef01a8413aa4e174b48bacd544\n",
+      "a9d4d04c8eb843f5a2c9e14b1fc45ec2 a9d4d04c8eb843f5a2c9e14b1fc45ec2\n",
+      "de16da55282a488c8837c74c88f2592b de16da55282a488c8837c74c88f2592b\n",
+      "02d608d08a1b4909aa730f790bdfee86 02d608d08a1b4909aa730f790bdfee86\n",
+      "837321f261514779ba0fb3d80951a7ea 837321f261514779ba0fb3d80951a7ea\n",
+      "6720029d6069444799d5a635add0d38e 6720029d6069444799d5a635add0d38e\n",
+      "15243508e5134a29bf121e1d1986898a 15243508e5134a29bf121e1d1986898a\n",
+      "9cd459b4012e41a885d84868ea2c1e31 9cd459b4012e41a885d84868ea2c1e31\n",
+      "d190e0cdcdff43ee843d9f1a1130a873 d190e0cdcdff43ee843d9f1a1130a873\n",
+      "c93690c25bea4ca3b09d22a833a4e12f c93690c25bea4ca3b09d22a833a4e12f\n",
+      "5b90fbb15e9a478ba616728300885c8e 5b90fbb15e9a478ba616728300885c8e\n",
+      "25dbda59f3c0462caad3005c15c613dc 25dbda59f3c0462caad3005c15c613dc\n",
+      "efd4bc43a1f14ea5904469eede1e1575 efd4bc43a1f14ea5904469eede1e1575\n",
+      "0aa12b11b2bf4b51a787013a958ef1fe 0aa12b11b2bf4b51a787013a958ef1fe\n",
+      "348aaf1cf2204b7ab0643c9a95ba24f0 348aaf1cf2204b7ab0643c9a95ba24f0\n",
+      "773d5129097a4282903a13f3a47edb9e 773d5129097a4282903a13f3a47edb9e\n",
+      "5c1b159db56f41af8b3d9af374af2bdc 5c1b159db56f41af8b3d9af374af2bdc\n",
+      "560dc1f66ab44e9b8ac2499f224dc1cc 560dc1f66ab44e9b8ac2499f224dc1cc\n",
+      "aae5f71061bd4f569f23ea49bdf32883 aae5f71061bd4f569f23ea49bdf32883\n",
+      "58c0f350d2dd4b0b9935705b34fd6eca 58c0f350d2dd4b0b9935705b34fd6eca\n",
+      "36e3eaa300d14fe7a292ff5f8041bd18 36e3eaa300d14fe7a292ff5f8041bd18\n",
+      "a6a451a385064e18b40e098344c70eba a6a451a385064e18b40e098344c70eba\n"
+     ]
+    }
+   ],
    "source": [
-    "for search in searches_list[:100]:\n",
+    "for search in searches_list[:50]:\n",
     "    print(search['id'], search['name'])"
    ]
   },
@@ -458,7 +670,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -469,9 +681,56 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 29,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'__daily_email_enabled': False,\n",
+       " '_links': {'_self': 'https://api.planet.com/data/v1/searches/1062d39a760c44a0b9f0a22f14070e7b',\n",
+       "  'results': 'https://api.planet.com/data/v1/searches/1062d39a760c44a0b9f0a22f14070e7b/results'},\n",
+       " 'created': '2022-12-09T20:35:54.228165Z',\n",
+       " 'filter': {'config': [{'config': {'coordinates': [[[-122.47455596923828,\n",
+       "        37.810326435534755],\n",
+       "       [-122.49172210693358, 37.795406713958236],\n",
+       "       [-122.52056121826172, 37.784282779035216],\n",
+       "       [-122.51953124999999, 37.6971326434885],\n",
+       "       [-122.38941192626953, 37.69441603823106],\n",
+       "       [-122.38872528076173, 37.705010235842614],\n",
+       "       [-122.36228942871092, 37.70935613533687],\n",
+       "       [-122.34992980957031, 37.727280276860036],\n",
+       "       [-122.37773895263672, 37.76230130281876],\n",
+       "       [-122.38494873046875, 37.794592824285104],\n",
+       "       [-122.40554809570311, 37.813310018173155],\n",
+       "       [-122.46150970458983, 37.805715207044685],\n",
+       "       [-122.47455596923828, 37.810326435534755]]],\n",
+       "     'type': 'Polygon'},\n",
+       "    'field_name': 'geometry',\n",
+       "    'type': 'GeometryFilter'},\n",
+       "   {'config': {'gt': 90.0},\n",
+       "    'field_name': 'clear_percent',\n",
+       "    'type': 'RangeFilter'},\n",
+       "   {'config': {'gt': '2017-01-01T00:00:00Z'},\n",
+       "    'field_name': 'acquired',\n",
+       "    'type': 'DateRangeFilter'},\n",
+       "   {'config': {'lt': 0.1},\n",
+       "    'field_name': 'cloud_cover',\n",
+       "    'type': 'RangeFilter'}],\n",
+       "  'type': 'AndFilter'},\n",
+       " 'id': '1062d39a760c44a0b9f0a22f14070e7b',\n",
+       " 'item_types': ['REOrthoTile', 'PSOrthoTile'],\n",
+       " 'last_executed': '2022-12-09T20:36:09.504776Z',\n",
+       " 'name': 'planet_client_demo',\n",
+       " 'search_type': 'saved',\n",
+       " 'updated': '2022-12-09T20:36:09.505035Z'}"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "search"
    ]
@@ -487,7 +746,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -500,11 +759,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"buckets\": [\n",
+      "    {\n",
+      "      \"count\": 375,\n",
+      "      \"start_time\": \"2018-01-01T00:00:00.000000Z\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"count\": 594,\n",
+      "      \"start_time\": \"2019-01-01T00:00:00.000000Z\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"count\": 665,\n",
+      "      \"start_time\": \"2020-01-01T00:00:00.000000Z\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"count\": 758,\n",
+      "      \"start_time\": \"2021-01-01T00:00:00.000000Z\"\n",
+      "    },\n",
+      "    {\n",
+      "      \"count\": 588,\n",
+      "      \"start_time\": \"2022-01-01T00:00:00.000000Z\"\n",
+      "    }\n",
+      "  ],\n",
+      "  \"interval\": \"year\",\n",
+      "  \"utc_offset\": \"+0h\"\n",
+      "}\n"
+     ]
+    }
+   ],
    "source": [
     "indent(stats)"
    ]


### PR DESCRIPTION
This ticket is directly related to [DEVREL-677](https://hello.planet.com/jira/browse/DEVREL-677), but is being separated out into it's own ticket, [DEVREL 927](https://hello.planet.com/jira/browse/DEVREL-927).  A current customer is relying on the code [in this particular notebook](https://github.com/planetlabs/notebooks/blob/master/jupyter-notebooks/data-api-tutorials/planet_python_client_introduction.ipynb) and would like to use the updated client code instead of doing asset download and activation manually.