### PR TITLE
Updated Orders client to new syntax.

### DIFF
--- a/jupyter-notebooks/gee-integration/gee-integration.ipynb
+++ b/jupyter-notebooks/gee-integration/gee-integration.ipynb
@@ -175,7 +175,7 @@
    "source": [
     "async with planet.Session() as ps:\n",
     "    # The Orders API client\n",
-    "    client = planet.OrdersClient(ps)\n",
+    "    client = ps.client('orders')\n",
     "    # Create the order and deliver it to GEE\n",
     "    order_details = await create_and_deliver_order(iowa_order, client)"
    ]
@@ -264,7 +264,7 @@
    "source": [
     "async with planet.Session() as ps:\n",
     "    # The Orders API client\n",
-    "    client = planet.OrdersClient(ps)\n",
+    "    client = ps.client('orders')\n",
     "    # Create the order and deliver it to GEE\n",
     "    order_details = await create_and_deliver_order(iowa_order, client)"
    ]


### PR DESCRIPTION
Updated the Orders client call to new syntax required by the Python client.

Namely, I change all instances of `client = planet.OrdersClient(ps)` to `client = ps.client('orders')`.

