### PR TITLE
[SEARCH-1186] Add quota usage warning to Search and Download Quickstart

### DIFF
--- a/jupyter-notebooks/Data-API/search_and_download_quickstart.ipynb
+++ b/jupyter-notebooks/Data-API/search_and_download_quickstart.ipynb
@@ -266,7 +266,9 @@
    "source": [
     " ## Activation and Downloading\n",
     " \n",
-    "The Data API does not pre-generate assets, so they are not always immediately availiable to download. In order to download an asset, we first have to **activate** it.\n",
+    "The Data API does not pre-generate assets, so they are not always immediately available to download. In order to download an asset, we first have to **activate** it.\n",
+    "\n",
+    "Please note that while this notebook's workflow is fast, it involves accessing a download link for full Planet scenes. Accessing this link will charge you for downloading the entire scene even if you only actually download metadata or a small clipped portion of the asset. Due to the quota model in place for the Data API, this is not as cost-effective as other methods. If you are working with a large amount of data and are concerned about quota, do not use this notebook and instead consider the [Orders API Clipping Tool](https://developers.planet.com/apis/orders/tools/#clip).\n",
     "\n",
     "Remember, earlier we decided we wanted a color-corrected image best suited for *analytic* applications. We can check the status of the PSScene 4-Band analytic asset we want to download like so:\n",
     " "


### PR DESCRIPTION
Customers have reported unexpectedly rapid quota consumption when using this notebook.  This MR adds a warning before the activation step to help prevent this.

This MR is very similar to (copies wording directly from) https://github.com/planetlabs/notebooks/pull/319