### PR TITLE
Adjust heading style

### DIFF
--- a/jupyter-notebooks/workflows/analysis-ready-data/ard_1_intro_and_best_practices.ipynb
+++ b/jupyter-notebooks/workflows/analysis-ready-data/ard_1_intro_and_best_practices.ipynb
@@ -606,7 +606,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "###### Option 2: Client CLI\n",
+    "##### Option 2: Client CLI\n",
     "\n",
     "In some instances, using the CLI to submit orders may be desired."
    ]


### PR DESCRIPTION
Cosmetic Update: The second option has been changed to Heading 3 instead of Heading 4, which is often too small in many IDEs.