### PR TITLE
[CSS-758] Add Permission Filter to example search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ ENV/
 
 # GDAL local cache directories
 gdalwmscache
+
+# IDE environments
+.idea/*

--- a/jupyter-notebooks/Data-API/search_and_download_quickstart.ipynb
+++ b/jupyter-notebooks/Data-API/search_and_download_quickstart.ipynb
@@ -154,10 +154,16 @@
     "  }\n",
     "}\n",
     "\n",
-    "# combine our geo, date, cloud filters\n",
+    "# get only images which this user has permission to download\n",
+    "permission_filter = {\n",
+    "  \"type\": \"PermissionFilter\",\n",
+    "  \"config\": [\"assets:download\"]\n",
+    "}\n",
+    "\n",
+    "# combine our geo, date, cloud, permission filters\n",
     "combined_filter = {\n",
     "  \"type\": \"AndFilter\",\n",
-    "  \"config\": [geometry_filter, date_range_filter, cloud_cover_filter]\n",
+    "  \"config\": [geometry_filter, date_range_filter, cloud_cover_filter, permission_filter]\n",
     "}"
    ]
   },


### PR DESCRIPTION
Add a Permission filter to the example search limiting items returned to ones the user can subsequently download later in the notebook.  This prevents permissions errors which disrupt the user's workflow.