### PR TITLE
Destinations API SDK Demo

### DIFF
--- a/jupyter-notebooks/api_guides/destinations_api/planet_sdk_destinations_demo.ipynb
+++ b/jupyter-notebooks/api_guides/destinations_api/planet_sdk_destinations_demo.ipynb
@@ -53,7 +53,7 @@
     "\n",
     "#### Supported Cloud Storage Destinations:\n",
     "* Amazon S3\n",
-    "    * Any other service that implements the S3 compatibility API\n",
+    "    * Most other services that implement the S3 compatibility API\n",
     "* Google Cloud Storage\n",
     "* Microsoft Azure Blob Storage\n",
     "* Oracle Cloud Storage\n",
@@ -345,7 +345,7 @@
    "id": "ea25128a",
    "metadata": {},
    "source": [
-    "To use this delivery method, use an account with `read`, `write`, and `delete` permissions for the bucket.\n",
+    "Other cloud hosting services that implement the S3 compatability API are allowed, with similar schema to the normal AWS delivery. To use this delivery method, use an account with `read`, `write`, and `delete` permissions for the bucket.\n",
     "\n",
     "Authentication is performed using an Access Key and Secret Key pair.\n",
     "\n",

--- a/jupyter-notebooks/api_guides/destinations_api/planet_sdk_destinations_demo.ipynb
+++ b/jupyter-notebooks/api_guides/destinations_api/planet_sdk_destinations_demo.ipynb
@@ -66,7 +66,7 @@
     "* All Destinations are rate limited to 3 requests per second.\n",
     "\n",
     "#### Destination Credentials\n",
-    "* Credentials used to create a Destination must have both `write` and `delete` permissions. \n",
+    "* Credentials used to create a Destination must have both `write` and `delete` permissions (the specific names of these permissions may vary).\n",
     "    * When a destination is created or updated, Planet verifies access by attempting to write and then delete a test file named `planetverify.txt`. \n",
     "    * If the permissions are correctly configured, this file will be removed immediately and will not appear in the storage bucket or container.* If you ever see this file, your credentials may be lacking the `delete` permissions needed.\n",
     "\n",
@@ -104,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 8,
    "id": "6b967c46",
    "metadata": {},
    "outputs": [],
@@ -112,6 +112,7 @@
     "import json\n",
     "import pathlib\n",
     "import planet\n",
+    "import getpass\n",
     "import os\n",
     "from datetime import datetime\n",
     "from planet import Auth, Planet, Session, DestinationsClient\n",
@@ -161,17 +162,227 @@
    "source": [
     "### Prepare Destination Credentials\n",
     "\n",
-    "[Add section description here]"
+    "Before you create a Destination, you must first complete the formation of a credentials dictionary. While this has slight variations between cloud provider, this will always have a `name`, a `type` (provider), with `parameters` that will contain the `bucket name` and some sort of `credential keys`. \n",
+    "\n",
+    "For convenience, placeholders for the various supported cloud storage providers will be in the cells below. The names of the specific permissions with also be listed.\n",
+    "\n",
+    "The various secret keys for credentials are meant to be placeholders, and can be set as environment variables to avoid pasting them in anywhere. Alternatively, they can be entered using `getpass` below."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "section1_code",
+   "id": "2c35e462",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Add your code here"
+    "# Use this variable in place of things like aws_secret_access_key, credentials_str, sas_token, etc.\n",
+    "credential_secret = getpass.getpass('credential secret:')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "section1_code",
+   "metadata": {},
+   "source": [
+    "#### <u>Amazon S3</u>\n",
+    "For Amazon S3 delivery use an AWS account with `GetObject`, `PutObject`, and `DeleteObject` permissions.\n",
+    "\n",
+    "You will also need a `aws_region`, `aws_access_key_id`, and `aws_secret_access_key`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cc9978ea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "name = 's3 destination'\n",
+    "bucket = 'bucket name'\n",
+    "aws_region = 'region name'\n",
+    "aws_access_key_id = 'access key id'\n",
+    "aws_secret_access_key = 'aws secret access key'\n",
+    "\n",
+    "bucket_creds = {\n",
+    "    \"name\": name,\n",
+    "    \"type\": \"amazon_s3\",\n",
+    "    \"parameters\": {\n",
+    "        \"bucket\": bucket,\n",
+    "        \"aws_region\": aws_region,\n",
+    "        \"aws_access_key_id\": aws_access_key_id,\n",
+    "        \"aws_secret_access_key\": aws_secret_access_key,\n",
+    "    },\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9e671b28",
+   "metadata": {},
+   "source": [
+    "#### <u> Google Cloud Storage </u>\n",
+    "\n",
+    "For Google Cloud Storage delivery, a service account with `storage.objects.create`, `storage.objects.get`, and `storage.objects.delete` permissions is required.\n",
+    "\n",
+    "***Important***: The Google Cloud Storage delivery option requires a single-line base64 version of the service account credentials for use by the credentials parameter.\n",
+    "\n",
+    "Download the service account credentials in JSON format (not P12) and encode them as a `base64` string, use a command line operation such as:\n",
+    "\n",
+    "```bash\n",
+    "cat my_creds.json | base64\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e9b5a7b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "name = 'GCS destination'\n",
+    "bucket_name = 'bucket name'\n",
+    "credentials_str = 'base64 str'\n",
+    "\n",
+    "bucket_creds = {\n",
+    "    \"name\": name,\n",
+    "    \"type\": \"google_cloud_storage\",\n",
+    "    \"parameters\": {\n",
+    "        \"bucket\": bucket_name,\n",
+    "        \"credentials\": credentials_str,\n",
+    "    },\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "36b9f9ff",
+   "metadata": {},
+   "source": [
+    "#### <u> Microsoft Azure Blob Storage </u>\n",
+    "\n",
+    "For Microsoft Azure delivery use an Azure account with `read`, `write`, `delete`, and `list` permissions.\n",
+    "\n",
+    "You will also need: `account name`, `container_name`, and `sas_token`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a62660cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "name = 'azure destination'\n",
+    "account = 'account name'\n",
+    "container_name = 'container name'\n",
+    "sas_token = 'token'\n",
+    "\n",
+    "# Optional: storage endpoint suffix:\n",
+    "# storage_endpoint_suffix = 'storage endpoint suffix'\n",
+    "\n",
+    "bucket_creds = {\n",
+    "    \"name\": name,\n",
+    "    \"type\": \"google_cloud_storage\",\n",
+    "    \"parameters\": {\n",
+    "        \"account\": account,\n",
+    "        \"container\": container_name,\n",
+    "        \"sas_token\": sas_token,\n",
+    "        #   \"storage_endpoint_suffix\": storage_endpoint_suffix, # optional\n",
+    "    },\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ce8c763a",
+   "metadata": {},
+   "source": [
+    "#### <u> Oracle Cloud Storage </u>\n",
+    "For Oracle Cloud Storage delivery, use an Oracle account with `read`, `write`, and `delete` permissions.\n",
+    "\n",
+    "For authentication, use a `Customer Secret Key` which consists of an `Access Key/Secret Key` pair."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4f0d6a8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "name = 'ocs name'\n",
+    "bucket_name = 'bucket name'\n",
+    "region = 'region'\n",
+    "namespace = 'namespace'\n",
+    "customer_access_key_id = 'customer_access_key_id'\n",
+    "customer_secret_key = 'customer_secret_key'\n",
+    "\n",
+    "bucket_creds = {\n",
+    "    \"name\": name,\n",
+    "    \"type\": \"oracle_cloud_storage\",\n",
+    "    \"parameters\": {\n",
+    "        \"bucket\": bucket_name,\n",
+    "        \"region\": region,\n",
+    "        \"namespace\": namespace,\n",
+    "        \"customer_access_key_id\": customer_access_key_id,\n",
+    "        \"customer_secret_key\": customer_secret_key,\n",
+    "    },\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2294b543",
+   "metadata": {},
+   "source": [
+    "#### <u> Other S3 Compatible Storage Providers </u>\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea25128a",
+   "metadata": {},
+   "source": [
+    "To use this delivery method, use an account with `read`, `write`, and `delete` permissions for the bucket.\n",
+    "\n",
+    "Authentication is performed using an Access Key and Secret Key pair.\n",
+    "\n",
+    "You will also need `endpoint`, and can optionally use a path style.\n",
+    "* Pay attention to the `use_path_style` parameter if you choose a path style, as it is a common source of issues.\n",
+    "    * For example, Oracle Cloud requires use_path_style to be true, while Open Telekom Cloud requires it to be false."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f20def83",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "name = 's3 compatible destination'\n",
+    "bucket = 'bucket name'\n",
+    "region = 'region name'\n",
+    "endpoint = 'endpoint'\n",
+    "access_key_id = 'access key id'\n",
+    "secret_access_key = 'secret access key'\n",
+    "\n",
+    "# Optional:\n",
+    "# use_path_style = False\n",
+    "\n",
+    "bucket_creds = {\n",
+    "    \"name\": name,\n",
+    "    \"type\": \"s3_compatible\",\n",
+    "    \"parameters\": {\n",
+    "        \"bucket\": bucket,\n",
+    "        \"region\": region,\n",
+    "        \"endpoint\": endpoint,\n",
+    "        \"access_key_id\": access_key_id,\n",
+    "        \"secret_access_key\": secret_access_key,\n",
+    "        # \"use_path_style\": use_path_style\n",
+    "    },\n",
+    "}"
    ]
   },
   {
@@ -184,12 +395,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4699d6bd",
+   "metadata": {},
+   "source": [
+    "___"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "section2_title",
    "metadata": {},
    "source": [
-    "### Section 2\n",
+    "### Destination Creation\n",
     "\n",
-    "[Add section description here]"
+    "Once you have setup your credentials dictionary above, you should use it to create a Destination:"
    ]
   },
   {
@@ -197,9 +416,41 @@
    "execution_count": null,
    "id": "section2_code",
    "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[31mSignature:\u001b[39m pl.destinations.create_destination(request: Dict[str, Any]) -> Dict\n",
+      "\u001b[31mDocstring:\u001b[39m\n",
+      "Create a new destination.\n",
+      "\n",
+      "Args:\n",
+      "    request (dict): Destination content to create, all attributes are required.\n",
+      "\n",
+      "Returns:\n",
+      "    dict: A dictionary containing the created destination details.\n",
+      "\n",
+      "Raises:\n",
+      "    APIError: If the API returns an error response.\n",
+      "    ClientError: If there is an issue with the client request.\n",
+      "\u001b[31mFile:\u001b[39m      ~/dev_env/public_repos/notebooks/.venv/lib/python3.13/site-packages/planet/sync/destinations.py\n",
+      "\u001b[31mType:\u001b[39m      method"
+     ]
+    }
+   ],
+   "source": [
+    "pl.destinations.create_destination(bucket_creds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1b4f542",
+   "metadata": {},
    "outputs": [],
    "source": [
-    "# Add your code here"
+    "Destination Reference ID's"
    ]
   },
   {

--- a/jupyter-notebooks/api_guides/destinations_api/planet_sdk_destinations_demo.ipynb
+++ b/jupyter-notebooks/api_guides/destinations_api/planet_sdk_destinations_demo.ipynb
@@ -63,7 +63,7 @@
     "* Each *organization* is provided a limitation of up to 50 Destinations, which will be both visible and usable by each individual within said organization.\n",
     "* The creator of a Destination is considered its *owner*, and, along with your organizational administrator, will be the only one allowed to modify a Destination.\n",
     "* All Destinations must have unique names.\n",
-    "* All Destinations are rate limited to 3 requests per second.\n",
+    "* All Destination API requests are rate limited to 3 requests per second.\n",
     "\n",
     "#### Destination Credentials Information\n",
     "* Credentials used to create a Destination must have both `write` and `delete` permissions (the specific names of these permissions may vary).\n",
@@ -105,18 +105,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "id": "6b967c46",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import json\n",
-    "import pathlib\n",
+    "import base64\n",
     "import planet\n",
     "import getpass\n",
-    "import os\n",
     "from datetime import datetime\n",
-    "from planet import Auth, Planet, Session, DestinationsClient, data_filter, order_request, reporting, subscription_request"
+    "from planet import data_filter, order_request, reporting, subscription_request"
    ]
   },
   {
@@ -227,11 +225,18 @@
     "\n",
     "***Important***: The Google Cloud Storage delivery option requires a single-line base64 version of the service account credentials for use by the credentials parameter.\n",
     "\n",
-    "Download the service account credentials in JSON format (not P12) and encode them as a `base64` string, use a command line operation such as:\n",
-    "\n",
-    "```bash\n",
-    "cat my_creds.json | base64\n",
-    "```"
+    "Download the service account credentials in JSON format (not P12) and use the following code with the `base64` module to encode the json as a string from a path:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "json_key_path = \"JSON FILE PATH\"\n",
+    "with open(json_key_path, \"rb\") as f:\n",
+    "        credentials_str = base64.b64encode(f.read()).decode()"
    ]
   },
   {
@@ -243,7 +248,6 @@
    "source": [
     "name = 'GCS destination'\n",
     "bucket_name = 'bucket name'\n",
-    "credentials_str = 'base64 str' # or credential_secret variable\n",
     "\n",
     "bucket_creds = {\n",
     "    \"name\": name,\n",

--- a/jupyter-notebooks/api_guides/destinations_api/planet_sdk_destinations_demo.ipynb
+++ b/jupyter-notebooks/api_guides/destinations_api/planet_sdk_destinations_demo.ipynb
@@ -105,7 +105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "6b967c46",
    "metadata": {},
    "outputs": [],
@@ -357,7 +357,8 @@
     "\n",
     "You will also need `endpoint`, and can optionally use a path style.\n",
     "* Pay attention to the `use_path_style` parameter if you choose a path style, as it is a common source of issues.\n",
-    "    * For example, Oracle Cloud requires use_path_style to be true, while Open Telekom Cloud requires it to be false."
+    "    * For example, Oracle Cloud requires use_path_style to be true, while Open Telekom Cloud requires it to be false.\n",
+    "    * For addtional examples, please visit the [Destination Documentation](https://docs.planet.com/develop/apis/destinations/#create-destination)."
    ]
   },
   {
@@ -737,7 +738,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 6,
    "id": "e4641659",
    "metadata": {},
    "outputs": [],
@@ -762,7 +763,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 12,
    "id": "section3_code",
    "metadata": {},
    "outputs": [],
@@ -770,15 +771,16 @@
     "# Define the filters we'll use to find our data\n",
     "\n",
     "item_types = [\"PSScene\"]\n",
-    "limit = 50\n",
+    "limit = 1 # Change your limit here to search for additional items\n",
     "\n",
     "# Filters for our search request\n",
     "geom_filter = data_filter.geometry_filter(geom)\n",
     "clear_percent_filter = data_filter.range_filter('clear_percent', 90)\n",
     "date_range_filter = data_filter.date_range_filter(\"acquired\", gt=datetime(month=1, day=1, year=2026))\n",
     "cloud_cover_filter = data_filter.range_filter('cloud_cover', None, 0.1)\n",
+    "asset_filter = data_filter.asset_filter(asset_types=[\"ortho_analytic_4b\", \"ortho_analytic_4b_xml\", \"ortho_udm2\"])\n",
     "\n",
-    "combined_filter = data_filter.and_filter([geom_filter, clear_percent_filter, date_range_filter, cloud_cover_filter])\n",
+    "combined_filter = data_filter.and_filter([geom_filter, clear_percent_filter, date_range_filter, cloud_cover_filter, asset_filter])\n",
     "\n",
     "search_request = pl.data.create_search(item_types=item_types, search_filter=combined_filter, name='planet_sdk_destination_demo')\n",
     "\n",
@@ -792,7 +794,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 13,
    "id": "ca70e908",
    "metadata": {},
    "outputs": [],
@@ -800,9 +802,11 @@
     "# Define request details to properly build your request\n",
     "\n",
     "item_ids = [item_id]\n",
+    "product_bundle = 'analytic_udm2'\n",
+    "item_type = 'PSScene'\n",
     "\n",
     "products = [\n",
-    "    order_request.product(item_ids, 'analytic_udm2', 'PSScene')\n",
+    "    order_request.product(item_ids, product_bundle, item_type)\n",
     "]\n",
     "\n",
     "tools = [\n",
@@ -816,7 +820,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 14,
    "id": "f0a7953a",
    "metadata": {},
    "outputs": [
@@ -827,7 +831,7 @@
        " 'products': [{'item_ids': ['20260212_192702_52_254a'],\n",
        "   'item_type': 'PSScene',\n",
        "   'product_bundle': 'analytic_udm2'}],\n",
-       " 'delivery': {'destination': {'ref': 'pl:destinations/demo-destination-5aIp1Kiqd76pOK4lWDy1Y'}},\n",
+       " 'delivery': {'destination': {'ref': 'pl:destinations/default'}},\n",
        " 'tools': [{'reproject': {'projection': 'EPSG:4326', 'kernel': 'cubic'}},\n",
        "  {'clip': {'aoi': {'type': 'Polygon',\n",
        "     'coordinates': [[[-122.47455596923828, 37.810326435534755],\n",
@@ -845,7 +849,7 @@
        "       [-122.47455596923828, 37.810326435534755]]]}}}]}"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/jupyter-notebooks/api_guides/destinations_api/planet_sdk_destinations_demo.ipynb
+++ b/jupyter-notebooks/api_guides/destinations_api/planet_sdk_destinations_demo.ipynb
@@ -13,11 +13,11 @@
    "id": "c5e76294",
    "metadata": {},
    "source": [
-    "This tutorial is an introduction to [Planet's](https://www.planet.com) Destination API using the official [Python client](https://github.com/planetlabs/planet-client-python), the `Planet` module. The Destination API allows you manage and securely store cloud storage bucket credentials as a 'Destination' for a product delivery on the Planet Platform. This can serve as an alternative to adding credentials to multiple workflows, for example, as the Destination can be set up once, and then referenced in different Order or Subscription requests.\n",
+    "This tutorial is an introduction to [Planet's](https://www.planet.com) Destination API using the official [Python client](https://github.com/planetlabs/planet-client-python), the `Planet` module. The Destination API allows you to manage and securely store cloud storage bucket credentials as a 'Destination' for a product delivery on the Planet Platform. This can serve as an alternative to adding credentials to multiple workflows, for example, as the Destination can be set up once, and then referenced in different Order or Subscription requests.\n",
     "\n",
     "## Requirements\n",
     "\n",
-    "An account on the [Planet Platform](https://www.planet.com/account/) is required to access any of Planet's API's. If you are not logged in, you will be prompted to do so below in the *SDK Authentication* section.\n",
+    "An account on the [Planet Platform](https://www.planet.com/account/) is required to access any of Planet's APIs. If you are not logged in, you will be prompted to do so below in the *SDK Authentication* section.\n",
     "\n",
     "## Useful links \n",
     "* [Planet SDK for Python](https://planet-sdk-for-python.readthedocs.io/en/stable/get-started/quick-start-guide/)\n",
@@ -60,7 +60,7 @@
     "\n",
     "\n",
     "#### Destinations Limitations:\n",
-    "* Each *organization* is provided a limitation of up to 50 Destinations, which will be both visible and usable by each individual within said organization.\n",
+    "* Each *organization* has a limitation of up to 50 Destinations, which will be both visible and usable by each individual within the organization.\n",
     "* The creator of a Destination is considered its *owner*, and, along with your organizational administrator, will be the only one allowed to modify a Destination.\n",
     "* All Destinations must have unique names.\n",
     "* All Destination API requests are rate limited to 3 requests per second.\n",
@@ -160,9 +160,9 @@
    "source": [
     "### Prepare Destination Credentials\n",
     "\n",
-    "Before you create a Destination, you must first complete the formation of a credentials dictionary. While this has slight variations between cloud provider, this will always have a `name`, a `type` (provider), with `parameters` that will contain the `bucket name` and some sort of `credential keys`. \n",
+    "Before you create a Destination, you must first complete the formation of a credentials dictionary. While this has slight variations between cloud providers, this will always have a `name`, a `type` (provider), with `parameters` that will contain the `bucket name` and some sort of `credential keys`. \n",
     "\n",
-    "For convenience, placeholders for the various supported cloud storage providers will be in the cells below. The names of the specific permissions with also be listed.\n",
+    "For convenience, placeholders for the various supported cloud storage providers will be in the cells below. The names of the specific permissions are also listed.\n",
     "\n",
     "The various secret keys for credentials are meant to be placeholders, and can be set as environment variables to avoid pasting them in anywhere. Alternatively, they can be entered using `getpass` below:"
    ]
@@ -270,7 +270,7 @@
     "\n",
     "You will also need: `account name`, `container_name`, and `sas_token`.\n",
     "\n",
-    "*If you not using the public Azure cloud endpoint `core.windows.net`, make sure to set yours with the `storage_endpoint_suffix` parameter. Usually this will be something like `core.usgovcloudapi.net` or `core.cloudapi.de`."
+    "*If you are not using the public Azure cloud endpoint `core.windows.net`, make sure to set yours with the `storage_endpoint_suffix` parameter. Usually this will be something like `core.usgovcloudapi.net` or `core.cloudapi.de`."
    ]
   },
   {
@@ -351,14 +351,14 @@
    "id": "ea25128a",
    "metadata": {},
    "source": [
-    "Other cloud hosting services that implement the S3 compatability API are allowed, with similar schema to the normal AWS delivery. To use this delivery method, use an account with `read`, `write`, and `delete` permissions for the bucket.\n",
+    "Other cloud hosting services that implement the S3 compatibility API are allowed, with similar schema to the normal AWS delivery. To use this delivery method, use an account with `read`, `write`, and `delete` permissions for the bucket.\n",
     "\n",
     "Authentication is performed using an Access Key and Secret Key pair.\n",
     "\n",
     "You will also need `endpoint`, and can optionally use a path style.\n",
     "* Pay attention to the `use_path_style` parameter if you choose a path style, as it is a common source of issues.\n",
     "    * For example, Oracle Cloud requires use_path_style to be true, while Open Telekom Cloud requires it to be false.\n",
-    "    * For addtional examples, please visit the [Destination Documentation](https://docs.planet.com/develop/apis/destinations/#create-destination)."
+    "    * For additional examples, please visit the [Destination Documentation](https://docs.planet.com/develop/apis/destinations/#create-destination)."
    ]
   },
   {
@@ -465,7 +465,7 @@
    "id": "e1b4f542",
    "metadata": {},
    "source": [
-    "### Destination ID and Reference ID's\n",
+    "### Destination ID and Reference IDs\n",
     "\n",
     "Once you have created your Destination, we will interact with it using its Reference ID, stored as the 'pl:ref' key. We will also save the ID of destination, stored as the 'id' key.\n",
     "\n",

--- a/jupyter-notebooks/api_guides/destinations_api/planet_sdk_destinations_demo.ipynb
+++ b/jupyter-notebooks/api_guides/destinations_api/planet_sdk_destinations_demo.ipynb
@@ -268,7 +268,9 @@
     "\n",
     "For Microsoft Azure delivery use an Azure account with `read`, `write`, `delete`, and `list` permissions.\n",
     "\n",
-    "You will also need: `account name`, `container_name`, and `sas_token`."
+    "You will also need: `account name`, `container_name`, and `sas_token`.\n",
+    "\n",
+    "*If you not using the public Azure cloud endpoint `core.windows.net`, make sure to set yours with the `storage_endpoint_suffix` parameter. Usually this will be something like `core.usgovcloudapi.net` or `core.cloudapi.de`."
    ]
   },
   {

--- a/jupyter-notebooks/api_guides/destinations_api/planet_sdk_destinations_demo.ipynb
+++ b/jupyter-notebooks/api_guides/destinations_api/planet_sdk_destinations_demo.ipynb
@@ -471,7 +471,7 @@
     "\n",
     "While it is confusing why we have both variables, you will notice that the Destination *Reference* ID contains the ID of the destination, with the added `pl:destinations/` string. \n",
     "\n",
-    "The Reference ID is used to reference a destination in other functions and API's, like Orders and Subscriptions. If you need to access or change any of the information held within a Destination, you will use the Destination ID (not the reference ID), using `pl.destinations.get_destination` and `pl.destination.patch_destination` respectively."
+    "The Reference ID is used to reference a destination in other functions and APIs, like Orders and Subscriptions. If you need to access or change any of the information held within a Destination, you will use the Destination ID (not the reference ID), using `pl.destinations.get_destination` and `pl.destination.patch_destination` respectively."
    ]
   },
   {

--- a/jupyter-notebooks/api_guides/destinations_api/planet_sdk_destinations_demo.ipynb
+++ b/jupyter-notebooks/api_guides/destinations_api/planet_sdk_destinations_demo.ipynb
@@ -1,0 +1,311 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "77185d9d",
+   "metadata": {},
+   "source": [
+    "# Planet Destinations Python Client Introduction"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5e76294",
+   "metadata": {},
+   "source": [
+    "This tutorial is an introduction to [Planet's](https://www.planet.com) Destination API using the official [Python client](https://github.com/planetlabs/planet-client-python), the `Planet` module. The Destination API allows you manage and securely store cloud storage bucket credentials as a 'Destination' for a product delivery on the Planet Platform. This can service as an alternative to adding credentials to multiple workflows, for example, as the Destination can be setup once, and then referenced in different Order or Subscription requests.\n",
+    "\n",
+    "## Requirements\n",
+    "\n",
+    "An account on the [Planet Platform](https://www.planet.com/account/) is required to access any of Planet's API's. If you are not logged in, you will be prompted to do so below in the *SDK Authentication* section.\n",
+    "\n",
+    "## Useful links \n",
+    "* [Planet SDK for Python](https://planet-sdk-for-python.readthedocs.io/en/stable/get-started/quick-start-guide/)\n",
+    "* [Planet Python Client Repo](https://github.com/planetlabs/planet-client-python)\n",
+    "* [Planet Destinations Documentation](https://docs.planet.com/develop/apis/destinations/)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1be92e24",
+   "metadata": {},
+   "source": [
+    "The basic workflow for interaction with the Destinations API is:\n",
+    "1. Prepare destination variables; mainly credentials and bucket name, with some other items depending on cloud storage provider.\n",
+    "2. Create Destination using the Destinations API\n",
+    "3. Use the Destination Reference ID in Orders and Subscription Requests."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b12f6b62",
+   "metadata": {},
+   "source": [
+    "____"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6de8ecc5",
+   "metadata": {},
+   "source": [
+    "## <u>Destination Information</u>\n",
+    "\n",
+    "#### Supported Cloud Storage Destinations:\n",
+    "* Amazon S3\n",
+    "    * Any other service that implements the S3 compatibility API\n",
+    "* Google Cloud Storage\n",
+    "* Microsoft Azure Blob Storage\n",
+    "* Oracle Cloud Storage\n",
+    "\n",
+    "\n",
+    "#### Detinations Limitations:\n",
+    "* Each *organization* is provided a limitation of up to 50 Destinations, which will be both visible and usable by each individual within said organization.\n",
+    "* The creator of a Destination is considered its *owner*, and, along with your organizational administrator, will be the only one allowed to modify a Destination.\n",
+    "* All Destinations must have unique names.\n",
+    "* All Destinations are rate limited to 3 requests per second.\n",
+    "\n",
+    "#### Destination Credentials\n",
+    "* Credentials used to create a Destination must have both `write` and `delete` permissions. \n",
+    "    * When a destination is created or updated, Planet verifies access by attempting to write and then delete a test file named `planetverify.txt`. \n",
+    "    * If the permissions are correctly configured, this file will be removed immediately and will not appear in the storage bucket or container.* If you ever see this file, your credentials may be lacking the `delete` permissions needed.\n",
+    "\n",
+    "#### Credential Security\n",
+    "* Destination credentials are treated as secrets which are encrypted at rest and in transit between Planet systems, accessed and decrypted only when strictly required, during a delivery.\n",
+    "* Destinations API will always redact these secrets in its responses.\n",
+    "    * You can update credentials via the Destination API, but never read them using it.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "90c47ef3",
+   "metadata": {},
+   "source": [
+    "____"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4d93f03",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "In order to interact with the Planet Destinations API using the Python client, we need to import the necessary packages and authenticate our Planet account credentials."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c69445b",
+   "metadata": {},
+   "source": [
+    "### Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "6b967c46",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import pathlib\n",
+    "import planet\n",
+    "import os\n",
+    "from datetime import datetime\n",
+    "from planet import Auth, Planet, Session, DestinationsClient\n",
+    "# Add additional imports as needed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8eb30bd9",
+   "metadata": {},
+   "source": [
+    "### SDK Authentication\n",
+    "\n",
+    "Your Planet login is used to authenticate and activate the Python SDK. You will be prompted via a link below to login and confirm on the page that the code displayed matches the authorization code printed. If this is your first time accessing the Planet SDK, you will also be prompted first to authorize the SDK access to your Planet account. \n",
+    "If you would like to know more, please visit the [authentication documentation](https://docs.planet.com/develop/authentication)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "78dde6ea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Authenticate for the Planet SDK; See docs: https://docs.planet.com/develop/authentication\n",
+    "# If you are not already logged in, this will prompt you to open a web browser to log in.\n",
+    "\n",
+    "auth = planet.Auth.from_profile('planet-user', save_state_to_storage=True)\n",
+    "auth.ensure_initialized(allow_open_browser=False, allow_tty_prompt=True)\n",
+    "\n",
+    "session = planet.Session(auth)\n",
+    "pl = planet.Planet(session)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "960dec0b",
+   "metadata": {},
+   "source": [
+    "_____"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "section1_title",
+   "metadata": {},
+   "source": [
+    "### Prepare Destination Credentials\n",
+    "\n",
+    "[Add section description here]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "section1_code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add your code here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "809f257d",
+   "metadata": {},
+   "source": [
+    "___"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "section2_title",
+   "metadata": {},
+   "source": [
+    "### Section 2\n",
+    "\n",
+    "[Add section description here]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "section2_code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add your code here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eaad89f4",
+   "metadata": {},
+   "source": [
+    "____"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "section3_title",
+   "metadata": {},
+   "source": [
+    "### Section 3\n",
+    "\n",
+    "[Add section description here]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "section3_code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add your code here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5d2b33e6",
+   "metadata": {},
+   "source": [
+    "_____"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "section4_title",
+   "metadata": {},
+   "source": [
+    "### Section 4\n",
+    "\n",
+    "[Add section description here]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "section4_code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add your code here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d8f60483",
+   "metadata": {},
+   "source": [
+    "___"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "section5_title",
+   "metadata": {},
+   "source": [
+    "### Section 5\n",
+    "\n",
+    "[Add section description here]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "section5_code",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add your code here"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv (3.13.7)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/jupyter-notebooks/api_guides/destinations_api/planet_sdk_destinations_demo.ipynb
+++ b/jupyter-notebooks/api_guides/destinations_api/planet_sdk_destinations_demo.ipynb
@@ -13,7 +13,7 @@
    "id": "c5e76294",
    "metadata": {},
    "source": [
-    "This tutorial is an introduction to [Planet's](https://www.planet.com) Destination API using the official [Python client](https://github.com/planetlabs/planet-client-python), the `Planet` module. The Destination API allows you manage and securely store cloud storage bucket credentials as a 'Destination' for a product delivery on the Planet Platform. This can service as an alternative to adding credentials to multiple workflows, for example, as the Destination can be setup once, and then referenced in different Order or Subscription requests.\n",
+    "This tutorial is an introduction to [Planet's](https://www.planet.com) Destination API using the official [Python client](https://github.com/planetlabs/planet-client-python), the `Planet` module. The Destination API allows you manage and securely store cloud storage bucket credentials as a 'Destination' for a product delivery on the Planet Platform. This can serve as an alternative to adding credentials to multiple workflows, for example, as the Destination can be set up once, and then referenced in different Order or Subscription requests.\n",
     "\n",
     "## Requirements\n",
     "\n",
@@ -59,16 +59,17 @@
     "* Oracle Cloud Storage\n",
     "\n",
     "\n",
-    "#### Detinations Limitations:\n",
+    "#### Destinations Limitations:\n",
     "* Each *organization* is provided a limitation of up to 50 Destinations, which will be both visible and usable by each individual within said organization.\n",
     "* The creator of a Destination is considered its *owner*, and, along with your organizational administrator, will be the only one allowed to modify a Destination.\n",
     "* All Destinations must have unique names.\n",
     "* All Destinations are rate limited to 3 requests per second.\n",
     "\n",
-    "#### Destination Credentials\n",
+    "#### Destination Credentials Information\n",
     "* Credentials used to create a Destination must have both `write` and `delete` permissions (the specific names of these permissions may vary).\n",
     "    * When a destination is created or updated, Planet verifies access by attempting to write and then delete a test file named `planetverify.txt`. \n",
-    "    * If the permissions are correctly configured, this file will be removed immediately and will not appear in the storage bucket or container.* If you ever see this file, your credentials may be lacking the `delete` permissions needed.\n",
+    "    * If the permissions are correctly configured, this file will be removed immediately and will not appear in the storage bucket or container.\n",
+    "    * If you ever see this file, your credentials may be lacking the `delete` permissions needed.\n",
     "\n",
     "#### Credential Security\n",
     "* Destination credentials are treated as secrets which are encrypted at rest and in transit between Planet systems, accessed and decrypted only when strictly required, during a delivery.\n",
@@ -89,7 +90,7 @@
    "id": "f4d93f03",
    "metadata": {},
    "source": [
-    "## Setup\n",
+    "## Set up\n",
     "\n",
     "In order to interact with the Planet Destinations API using the Python client, we need to import the necessary packages and authenticate our Planet account credentials."
    ]
@@ -104,7 +105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 39,
    "id": "6b967c46",
    "metadata": {},
    "outputs": [],
@@ -115,8 +116,7 @@
     "import getpass\n",
     "import os\n",
     "from datetime import datetime\n",
-    "from planet import Auth, Planet, Session, DestinationsClient\n",
-    "# Add additional imports as needed"
+    "from planet import Auth, Planet, Session, DestinationsClient, data_filter, order_request, reporting, subscription_request"
    ]
   },
   {
@@ -132,7 +132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 40,
    "id": "78dde6ea",
    "metadata": {},
    "outputs": [],
@@ -166,12 +166,12 @@
     "\n",
     "For convenience, placeholders for the various supported cloud storage providers will be in the cells below. The names of the specific permissions with also be listed.\n",
     "\n",
-    "The various secret keys for credentials are meant to be placeholders, and can be set as environment variables to avoid pasting them in anywhere. Alternatively, they can be entered using `getpass` below."
+    "The various secret keys for credentials are meant to be placeholders, and can be set as environment variables to avoid pasting them in anywhere. Alternatively, they can be entered using `getpass` below:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 41,
    "id": "2c35e462",
    "metadata": {},
    "outputs": [],
@@ -202,7 +202,7 @@
     "bucket = 'bucket name'\n",
     "aws_region = 'region name'\n",
     "aws_access_key_id = 'access key id'\n",
-    "aws_secret_access_key = 'aws secret access key'\n",
+    "aws_secret_access_key = 'aws secret access key' # or credential_secret variable\n",
     "\n",
     "bucket_creds = {\n",
     "    \"name\": name,\n",
@@ -243,7 +243,7 @@
    "source": [
     "name = 'GCS destination'\n",
     "bucket_name = 'bucket name'\n",
-    "credentials_str = 'base64 str'\n",
+    "credentials_str = 'base64 str' # or credential_secret variable\n",
     "\n",
     "bucket_creds = {\n",
     "    \"name\": name,\n",
@@ -277,14 +277,14 @@
     "name = 'azure destination'\n",
     "account = 'account name'\n",
     "container_name = 'container name'\n",
-    "sas_token = 'token'\n",
+    "sas_token = 'token' # or credential_secret variable\n",
     "\n",
     "# Optional: storage endpoint suffix:\n",
     "# storage_endpoint_suffix = 'storage endpoint suffix'\n",
     "\n",
     "bucket_creds = {\n",
     "    \"name\": name,\n",
-    "    \"type\": \"google_cloud_storage\",\n",
+    "    \"type\": \"azure_blob_storage\",\n",
     "    \"parameters\": {\n",
     "        \"account\": account,\n",
     "        \"container\": container_name,\n",
@@ -317,7 +317,7 @@
     "region = 'region'\n",
     "namespace = 'namespace'\n",
     "customer_access_key_id = 'customer_access_key_id'\n",
-    "customer_secret_key = 'customer_secret_key'\n",
+    "customer_secret_key = 'customer_secret_key' # or credential_secret variable\n",
     "\n",
     "bucket_creds = {\n",
     "    \"name\": name,\n",
@@ -366,7 +366,7 @@
     "region = 'region name'\n",
     "endpoint = 'endpoint'\n",
     "access_key_id = 'access key id'\n",
-    "secret_access_key = 'secret access key'\n",
+    "secret_access_key = 'secret access key' # or credential_secret variable\n",
     "\n",
     "# Optional:\n",
     "# use_path_style = False\n",
@@ -387,14 +387,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "809f257d",
-   "metadata": {},
-   "source": [
-    "___"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "4699d6bd",
    "metadata": {},
    "source": [
@@ -408,7 +400,17 @@
    "source": [
     "### Destination Creation\n",
     "\n",
-    "Once you have setup your credentials dictionary above, you should use it to create a Destination:"
+    "Once you have set up your credentials dictionary above, you should use it to create a Destination:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36dadc12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_destination = pl.destinations.create_destination(bucket_creds)"
    ]
   },
   {
@@ -418,39 +420,247 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[31mSignature:\u001b[39m pl.destinations.create_destination(request: Dict[str, Any]) -> Dict\n",
-      "\u001b[31mDocstring:\u001b[39m\n",
-      "Create a new destination.\n",
-      "\n",
-      "Args:\n",
-      "    request (dict): Destination content to create, all attributes are required.\n",
-      "\n",
-      "Returns:\n",
-      "    dict: A dictionary containing the created destination details.\n",
-      "\n",
-      "Raises:\n",
-      "    APIError: If the API returns an error response.\n",
-      "    ClientError: If there is an issue with the client request.\n",
-      "\u001b[31mFile:\u001b[39m      ~/dev_env/public_repos/notebooks/.venv/lib/python3.13/site-packages/planet/sync/destinations.py\n",
-      "\u001b[31mType:\u001b[39m      method"
-     ]
+     "data": {
+      "text/plain": [
+       "{'_links': {'_self': 'https://api.planet.com/destinations/v1/demo-destination-5aIp1Kiqd76pOK4lWDy1Y'},\n",
+       " 'archived': None,\n",
+       " 'created': '2026-02-12T18:41:22.659959594Z',\n",
+       " 'default': False,\n",
+       " 'id': 'demo-destination-5aIp1Kiqd76pOK4lWDy1Y',\n",
+       " 'name': 'demo destination',\n",
+       " 'ownership': {'is_owner': True, 'owner_id': '<owner_id>'},\n",
+       " 'parameters': {'bucket': 'simon-test-bucket-pl', 'credentials': '<REDACTED>'},\n",
+       " 'permissions': {'can_write': True},\n",
+       " 'pl:ref': 'pl:destinations/demo-destination-5aIp1Kiqd76pOK4lWDy1Y',\n",
+       " 'type': 'google_cloud_storage',\n",
+       " 'updated': '2026-02-12T18:41:22.659960762Z'}"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "pl.destinations.create_destination(bucket_creds)"
+    "new_destination"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b88d6db",
+   "metadata": {},
+   "source": [
+    "_____"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1b4f542",
+   "metadata": {},
+   "source": [
+    "### Destination ID and Reference ID's\n",
+    "\n",
+    "Once you have created your Destination, we will interact with it using its Reference ID, stored as the 'pl:ref' key. We will also save the ID of destination, stored as the 'id' key.\n",
+    "\n",
+    "While it is confusing why we have both variables, you will notice that the Destination *Reference* ID contains the ID of the destination, with the added `pl:destinations/` string. \n",
+    "\n",
+    "The Reference ID is used to reference a destination in other functions and API's, like Orders and Subscriptions. If you need to access or change any of the information held within a Destination, you will use the Destination ID (not the reference ID), using `pl.destinations.get_destination` and `pl.destination.patch_destination` respectively."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e1b4f542",
+   "id": "7a163814",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Destination id: demo-destination-5aIp1Kiqd76pOK4lWDy1Y\n",
+      "Destination Reference ID: pl:destinations/demo-destination-5aIp1Kiqd76pOK4lWDy1Y\n"
+     ]
+    }
+   ],
+   "source": [
+    "dest_ref_id = new_destination['pl:ref']\n",
+    "destination_id = new_destination['id']\n",
+    "\n",
+    "print(f'Destination id: {destination_id}')\n",
+    "print(f'Destination Reference ID: {dest_ref_id}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2a489197",
+   "metadata": {},
+   "source": [
+    "### Other Destinations API Functions:\n",
+    "\n",
+    "* Listing Destinations\n",
+    "* Modify a Destination\n",
+    "    * *Only Authentication parameters may be modified for a destination. Bucket names, regions, etc, may not be changed.*\n",
+    "* Setting a Default Destination\n",
+    "* Unset a Default Destination\n",
+    "    * *All users in an organization may access the Default Destination, but only the admin may set and unset it*\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f1833ec",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "You have access to 1 destinations.\n"
+     ]
+    }
+   ],
+   "source": [
+    "all_destinations = pl.destinations.list_destinations()\n",
+    "print(f'You have access to {len(all_destinations['destinations'])} destinations.')\n",
+    "\n",
+    "all_destinations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd0877d0",
+   "metadata": {},
+   "source": [
+    "#### Access a specific Destination\n",
+    "\n",
+    "If you have a `Destination_id` but need the rest of the key value pairs belonging to it, use `get_destination.`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2c8f0e1f",
    "metadata": {},
    "outputs": [],
    "source": [
-    "Destination Reference ID's"
+    "pl.destinations.get_destination(destination_id)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e07ea49e",
+   "metadata": {},
+   "source": [
+    "#### Patching a Destination\n",
+    "\n",
+    "If you make changes to your bucket's access credentials, you can use `patch_destination` to update them. You can **only** update credentials/secrets with this method.\n",
+    "\n",
+    "We will not be listing every method every cloud provider here, but you will need to change the `credential` key to match your provider, `aws_secret_access_key` for AWS, `sas_token` for Azure, etc."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30e984c9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_credentials = ''\n",
+    "\n",
+    "dest_param_to_update = {\n",
+    "    'credentials' : new_credentials\n",
+    "}\n",
+    "\n",
+    "pl.destinations.patch_destination(destination_id, dest_param_to_update)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "79515e1b",
+   "metadata": {},
+   "source": [
+    "_____"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0cfeed69",
+   "metadata": {},
+   "source": [
+    "#### Set your Default Destination *For Organizational Admins Only*\n",
+    "\n",
+    "Setting your Default Destination is a quick way to speed up delivery with Orders and Subscriptions with the Destinations API. Note that changing the Default Destination is a power *only available to an organization's admin account*. The following functions will not be available at all in the SDK if you are not your organization's admin. If you are not the admin, feel free to skip this section of the tutorial. \n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f0fa5e43",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'_links': {'_self': 'https://api.planet.com/destinations/v1/demo-destination-5aIp1Kiqd76pOK4lWDy1Y'},\n",
+       " 'archived': None,\n",
+       " 'created': '2026-02-12T18:41:22.659959594Z',\n",
+       " 'default': True,\n",
+       " 'id': 'demo-destination-5aIp1Kiqd76pOK4lWDy1Y',\n",
+       " 'name': 'demo destination',\n",
+       " 'ownership': {'is_owner': True, 'owner_id': '<owner_id>'},\n",
+       " 'parameters': {'bucket': 'simon-test-bucket-pl', 'credentials': '<REDACTED>'},\n",
+       " 'permissions': {'can_write': True},\n",
+       " 'pl:ref': 'pl:destinations/demo-destination-5aIp1Kiqd76pOK4lWDy1Y',\n",
+       " 'type': 'google_cloud_storage',\n",
+       " 'updated': '2026-02-12T18:41:22.659960762Z'}"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "default_destination = pl.destinations.set_default_destination(dest_ref_id)\n",
+    "default_destination"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07ffe8a5",
+   "metadata": {},
+   "source": [
+    "You can also 'unset' a destination from the default. This requires no input and will have no output:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f4324c31",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Uncomment this if you need to unset your default destination.\n",
+    "# pl.destinations.unset_default_destination()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f3e6ceb",
+   "metadata": {},
+   "source": [
+    "Once the default destination is set, it can be used in the `delivery` input in Orders and Subscriptions. If you set your default destination above, you don't need to run this cell, as the setting the default_destination will have the same output as getting it. However we are providing it as a template."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "1a46e1be",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "default_destination = pl.destinations.get_default_destination()"
    ]
   },
   {
@@ -466,75 +676,222 @@
    "id": "section3_title",
    "metadata": {},
    "source": [
-    "### Section 3\n",
+    "### Using the Destination in other API calls.\n",
     "\n",
-    "[Add section description here]"
+    "Once you have a Destination set up, you can use its Reference ID as the `delivery` argument for Orders and Subscriptions. There are some handy functions for setting a `destination` or `default_destination` from both the `order_request` and `subscription_request` submodules that we will use.\n",
+    "\n",
+    " We will reuse the variable `dest_ref_id` we created before to demonstrate this by creating a Data API search request for imagery of San Francisco, and Order a PlanetScope Scene that will be clipped and delivered to our new Destination. Using a destination in a Subscription will follow a very similar pattern.\n",
+    "\n",
+    "*WARNING* - Ordering Imagery like this will consume some of your quota. If you wish to follow this demo anyways, feel free to change the parameters to an AOI/TOI/asset types/ etc. that will be useful and relevant to you. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d64ab95d",
+   "metadata": {},
+   "source": [
+    "#### Order Requests:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "49ab6f94",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "destination_dict = order_request.destination(dest_ref_id)\n",
+    "\n",
+    "# Use this instead to use a default_destination:\n",
+    "\n",
+    "# destination_dict = order_request.default_destination()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f31ff8a0",
+   "metadata": {},
+   "source": [
+    "#### Subscription Requests:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ec37ab3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "destination_dict = subscription_request.destination(dest_ref_id)\n",
+    "\n",
+    "# Use this instead to use a default_destination:\n",
+    "\n",
+    "# destination_dict = subscription_request.default_destination()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "e4641659",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# San Francisco Geometry\n",
+    "\n",
+    "geom = {'type': 'Polygon',\n",
+    " 'coordinates': [[[-122.47455596923828, 37.810326435534755],\n",
+    "   [-122.49172210693358, 37.795406713958236],\n",
+    "   [-122.52056121826172, 37.784282779035216],\n",
+    "   [-122.51953124999999, 37.6971326434885],\n",
+    "   [-122.38941192626953, 37.69441603823106],\n",
+    "   [-122.38872528076173, 37.705010235842614],\n",
+    "   [-122.36228942871092, 37.70935613533687],\n",
+    "   [-122.34992980957031, 37.727280276860036],\n",
+    "   [-122.37773895263672, 37.76230130281876],\n",
+    "   [-122.38494873046875, 37.794592824285104],\n",
+    "   [-122.40554809570311, 37.813310018173155],\n",
+    "   [-122.46150970458983, 37.805715207044685],\n",
+    "   [-122.47455596923828, 37.810326435534755]]]}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
    "id": "section3_code",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Add your code here"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5d2b33e6",
-   "metadata": {},
-   "source": [
-    "_____"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "section4_title",
-   "metadata": {},
-   "source": [
-    "### Section 4\n",
+    "# Define the filters we'll use to find our data\n",
     "\n",
-    "[Add section description here]"
+    "item_types = [\"PSScene\"]\n",
+    "limit = 50\n",
+    "\n",
+    "# Filters for our search request\n",
+    "geom_filter = data_filter.geometry_filter(geom)\n",
+    "clear_percent_filter = data_filter.range_filter('clear_percent', 90)\n",
+    "date_range_filter = data_filter.date_range_filter(\"acquired\", gt=datetime(month=1, day=1, year=2026))\n",
+    "cloud_cover_filter = data_filter.range_filter('cloud_cover', None, 0.1)\n",
+    "\n",
+    "combined_filter = data_filter.and_filter([geom_filter, clear_percent_filter, date_range_filter, cloud_cover_filter])\n",
+    "\n",
+    "search_request = pl.data.create_search(item_types=item_types, search_filter=combined_filter, name='planet_sdk_destination_demo')\n",
+    "\n",
+    "\n",
+    "# Search the Data API\n",
+    "search_id = search_request['id']\n",
+    "item_list = pl.data.run_search(search_id=search_id, limit=limit)\n",
+    "item_list = list(item_list)\n",
+    "item_id = item_list[0]['id']"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "section4_code",
+   "execution_count": 50,
+   "id": "ca70e908",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Add your code here"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d8f60483",
-   "metadata": {},
-   "source": [
-    "___"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "section5_title",
-   "metadata": {},
-   "source": [
-    "### Section 5\n",
+    "# Define request details to properly build your request\n",
     "\n",
-    "[Add section description here]"
+    "item_ids = [item_id]\n",
+    "\n",
+    "products = [\n",
+    "    order_request.product(item_ids, 'analytic_udm2', 'PSScene')\n",
+    "]\n",
+    "\n",
+    "tools = [\n",
+    "    order_request.reproject_tool(projection='EPSG:4326', kernel='cubic'),\n",
+    "    order_request.clip_tool(geom)\n",
+    "]\n",
+    "\n",
+    "order_built = order_request.build_request(\n",
+    "    'destination_test_order', products=products, tools=tools, delivery=destination_dict)\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
+   "id": "f0a7953a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'name': 'destination_test_order',\n",
+       " 'products': [{'item_ids': ['20260212_192702_52_254a'],\n",
+       "   'item_type': 'PSScene',\n",
+       "   'product_bundle': 'analytic_udm2'}],\n",
+       " 'delivery': {'destination': {'ref': 'pl:destinations/demo-destination-5aIp1Kiqd76pOK4lWDy1Y'}},\n",
+       " 'tools': [{'reproject': {'projection': 'EPSG:4326', 'kernel': 'cubic'}},\n",
+       "  {'clip': {'aoi': {'type': 'Polygon',\n",
+       "     'coordinates': [[[-122.47455596923828, 37.810326435534755],\n",
+       "       [-122.49172210693358, 37.795406713958236],\n",
+       "       [-122.52056121826172, 37.784282779035216],\n",
+       "       [-122.51953124999999, 37.6971326434885],\n",
+       "       [-122.38941192626953, 37.69441603823106],\n",
+       "       [-122.38872528076173, 37.705010235842614],\n",
+       "       [-122.36228942871092, 37.70935613533687],\n",
+       "       [-122.34992980957031, 37.727280276860036],\n",
+       "       [-122.37773895263672, 37.76230130281876],\n",
+       "       [-122.38494873046875, 37.794592824285104],\n",
+       "       [-122.40554809570311, 37.813310018173155],\n",
+       "       [-122.46150970458983, 37.805715207044685],\n",
+       "       [-122.47455596923828, 37.810326435534755]]]}}}]}"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "order_built"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "id": "be214464",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "New Order Created: 9747430b-0886-4bf7-a7ef-33d1bd33fd8c\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "05:30 - order  - state: success\n"
+     ]
+    }
+   ],
+   "source": [
+    "created_order = pl.orders.create_order(order_built)\n",
+    "order_id = created_order['id']\n",
+    "print(f'New Order Created: {order_id}')\n",
+    "\n",
+    "with reporting.StateBar() as bar:\n",
+    "    pl.orders.wait(order_id, callback=bar.update_state, delay=10,max_attempts=500)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "380cec46",
+   "metadata": {},
+   "source": [
+    "____"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "section5_code",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "# Add your code here"
+    "Congratulations! You have completed the Destinations API demo! You now have the tools to set up destinations for your organizations, which make your product deliveries more secure. Feel free to use your Destinations in any future Orders and Subscriptions that you create."
    ]
   }
  ],


### PR DESCRIPTION
Notebook containing a demo for the Destinations API using the Plant Python SDK. Walks users through setting up destinations to use in orders and subscriptions, and provides snippets for use. There is a short example of how to use a destination in a planetscope order at the end that delivers to the destination that gets set up.